### PR TITLE
feat: Support consistent flag in check command

### DIFF
--- a/parser/match.go
+++ b/parser/match.go
@@ -1,0 +1,38 @@
+package parser
+
+import (
+	"context"
+	"fmt"
+	"github.com/sethvargo/ratchet/resolver"
+	"gopkg.in/yaml.v3"
+	"strconv"
+)
+
+type Match struct {
+	ref        string
+	constraint string
+	line       string
+}
+
+func NewMatch(ref string, node *yaml.Node) Match {
+	originalConstraint, _ := extractOriginalFromComment(node.LineComment)
+	return Match{
+		ref:        ref,
+		constraint: originalConstraint,
+		line:       strconv.Itoa(node.Line),
+	}
+}
+
+func refConsistentWithOriginalConstraint(ctx context.Context, ref string, res resolver.Resolver, m *yaml.Node) (bool, error) {
+	originalConstraint, _ := extractOriginalFromComment(m.LineComment)
+	r, err := res.Resolve(ctx, fmt.Sprintf("%s%s", resolver.RefPrefix(ref), originalConstraint))
+	if err != nil {
+		return false, fmt.Errorf("resolve %v", err)
+	}
+
+	if r != resolver.DenormalizeRef(ref) {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -61,3 +61,14 @@ func DenormalizeRef(in string) string {
 	in = strings.TrimPrefix(in, ContainerProtocol)
 	return in
 }
+
+// RefPrefix gets the reference prefix.
+func RefPrefix(in string) string {
+	if strings.HasPrefix(in, ActionsProtocol) {
+		in = ActionsProtocol
+	}
+	if strings.HasPrefix(in, ContainerProtocol) {
+		in = ActionsProtocol
+	}
+	return in
+}


### PR DESCRIPTION
First off all, thanks for this cool project!  🙏🏾 

I started to use this in my Github CI workflows and found out a thing i was thinking of submitting an issue, but its boring so i tried me on a PR.

Ive set it up similar to this;

```yaml
name: Check pinned workflows
on:
  push:
    paths:
      - '.github/workflows/**'
jobs:
  ratchet:
    runs-on: ubuntu-20.04
    steps:
      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # ratchet:actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
      - name: Check if main.yml is pinned
        uses: 'docker://ghcr.io/sethvargo/ratchet@sha256:35c4b5f020000ee9c77a4af7cbe04f1d3e88718e533e6cb949146d4dc2c89220' # ratchet:docker://ghcr.io/sethvargo/ratchet:0.2.1
        with:
          args: 'check .github/workflows/main.yml'
```

But i noticed when using automated dependency updates, like Dependabot, it updates but, it makes the ratchet inconsistent, the original constraint dont match the update, example;

before PR;

```yaml
- name: Upload
        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # ratchet:actions/upload-artifact@v2
```

after PR;

```yaml
      - name: Upload
        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # ratchet:actions/upload-artifact@v2
```

The comment constraint `# ratchet:actions/upload-artifact@v2` should in this case be `# ratchet:actions/upload-artifact@v3`

With this useful flag `--consistent` with `check` command in Ratchet when in a CI environment and activated automated dependency updates e.g. Dependabot, the workflow will fail fast with a message: `found 1 mismatch between ref and constraint: [{"good/repo@2541b1294d2704b0964813337f33b291d3f8596b" "good/repo@v0" "4"}]` and you have to update the version, keeping the inconsistency  away 🗡️ ..
