### PR TITLE
Draft: Support variable resolution in Gitlab CI

### DIFF
--- a/parser/gitlabci.go
+++ b/parser/gitlabci.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/sethvargo/ratchet/resolver"
 	"gopkg.in/yaml.v3"
@@ -69,7 +70,10 @@ func (C *GitLabCI) Parse(m *yaml.Node) (*RefsList, error) {
 						imageRef = image
 					}
 
-					ref := resolver.NormalizeContainerRef(imageRef.Value)
+					// Expand variables
+					var expandedImageName = os.ExpandEnv(imageRef.Value)
+
+					ref := resolver.NormalizeContainerRef(expandedImageName)
 					refs.Add(ref, imageRef)
 				}
 			}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -150,9 +150,24 @@ func Pin(ctx context.Context, res resolver.Resolver, parser Parser, m *yaml.Node
 
 			denormRef := resolver.DenormalizeRef(ref)
 
+			split := func(imageRef string, splitOn string) (s string) {
+				arr := strings.Split(imageRef, splitOn)
+				if len(arr) == 1 {
+					return ""
+				}
+				return arr[len(arr)-1]
+			}
+
+			tag := split(denormRef, ":")
+			hash := split(resolved, "@")
+
 			for _, node := range nodes {
 				node.LineComment = appendOriginalToComment(node.LineComment, node.Value)
-				node.Value = strings.Replace(node.Value, denormRef, resolved, 1)
+				if tag != "" {
+					node.Value = strings.Replace(node.Value, ":"+tag, "@"+hash, 1)
+				} else {
+					node.Value += "@" + hash
+				}
 			}
 		}()
 	}


### PR DESCRIPTION
## Summary

This PR adds support for resolving variables in image references for GitLab CI.

This PR is a draft. Variables are handled as expected when running `pin`, `check`, and `unpin`. Here is a GitLab CI job where I tested pinning: https://gitlab.com/gitlab-org/gitlab/-/jobs/3508300700. However, the unit tests are broken. I have not tested if the changes interfere with functionality for other CIs.

Before working more on this, I want to reach out to see if there is interest in merging this feature.

## Implementation

Image references in GitLab CI can contain $variables. During runtime, GitLab runner expands variables based on the configured environment variables. For details, see https://docs.gitlab.com/ee/ci/variables/where_variables_can_be_used.html#gitlab-runner-internal-variable-expansion-mechanism. Variables are rather common in CI configs, hence it's useful to support them in ratchet as well.

This PR adds code to resolve variables in image references in the same fashion as GitLab Runner does. GitLab Runner is also written in go which allows using the same library function, i.e. `os.ExpandEnv()`.  `parser.go` is changed so that only the tag is replaced with the digest (the current implementation replaces the entire image reference).