### PR TITLE
Improve usage of the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM --platform=$BUILDPLATFORM alpine AS builder
-
-FROM scratch
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-
+FROM cgr.dev/chainguard/static:latest-20230102
 # Normally we would set this to run as "nobody", but to play nicely with GitHub
 # Actions, it must run as the default user:
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM cgr.dev/chainguard/static:latest-20230102
 #   https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user
 #
 # USER nobody
+WORKDIR /ws
+ENV PATH /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/ratchet"]
 
-COPY ratchet /ratchet
-ENTRYPOINT ["/ratchet"]
+COPY ratchet /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ image: 'ubuntu@sha256:47f14534bda344d9fe6ffd6effb95eefe579f4be0d508b7445cf77f61a
 **⚠️ Warning!** The README corresponds to the `main` branch of ratchet's
 development, and it may contain unreleased features.
 
-**Pin to specific versions:**
+### Pin to specific versions
 
 ```shell
 # pin the input file
@@ -75,7 +75,7 @@ development, and it may contain unreleased features.
 ./ratchet pin -out workflow-compiled.yml workflow.yml
 ```
 
-**Unpin existing pinned versions:**
+### Unpin existing pinned versions
 
 ```shell
 # unpin the input file
@@ -85,7 +85,7 @@ development, and it may contain unreleased features.
 ./ratchet unpin -out workflow.yml workflow-compiled.yml
 ```
 
-**Update all versions to the latest matching constraint:**
+### Update all versions to the latest matching constraint
 
 ```shell
 # update the input file
@@ -104,13 +104,13 @@ development, and it may contain unreleased features.
 For more information, run a command with `-help` to use detailed usage
 instructions.
 
-**Check if all versions are pinned:**
+### Check if all versions are pinned
 
 ```shell
 ./ratchet check workflow.yml
 ```
 
-**In a CI/CD workflow:**
+### In a CI/CD workflow
 
 Ratchet is distributed as a very small container, so you can use it as a step
 inside CI/CD jobs. Here is a GitHub Actions example:
@@ -144,14 +144,14 @@ Using this approach you won't have to install any binary into your local system.
 > **Note**: When mapping the volume to `/ws` you will be able to still benefit from completion on your filepaths.
 
 ```shell
-docker run --rm --volume $PWD:/ws ghcr.io/sethvargo/ratchet:0.4.0 pin .github/workflows/ci.yaml
+docker run --rm --volume "$PWD:/ws" ghcr.io/sethvargo/ratchet:0.4.0 pin .github/workflows/ci.yaml
 ```
 
 Or create yourself an alias in your `~/.bashrc` or `~/.zshrc`
 
 ```shell
 function ratchet {
-  docker run --rm --volume $PWD:/ws ghcr.io/sethvargo/ratchet:0.4.0
+  docker run --rm --volume "$PWD:/ws" ghcr.io/sethvargo/ratchet:0.4.0 "$@"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,23 @@ jobs:
 This same pattern can be extended to other CI/CD systems that support
 container-based runtimes.
 
+### Inside a docker container
+
+Using this approach you won't have to install any binary into your local system.
+
+> **Note**: When mapping the volume to `/ws` you will be able to still benefit from completion on your filepaths.
+
+```shell
+docker run --rm --volume $PWD:/ws ghcr.io/sethvargo/ratchet:0.4.0 pin .github/workflows/ci.yaml
+```
+
+Or create yourself an alias in your `~/.bashrc` or `~/.zshrc`
+
+```shell
+function ratchet {
+  docker run --rm --volume $PWD:/ws ghcr.io/sethvargo/ratchet:0.4.0
+}
+```
 
 ## Installation
 


### PR DESCRIPTION
This PR improves the usage of the Docker image by using a WORKDIR (You can't mount a volume at `/`).

Also it improves the Dockerfile itself by using chainguards static image which ships automatically with

- ca-certs
- tzdata

