### PR TITLE
feat: add flag to undo newline changes caused by yaml formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ only applies to the line on which it appears.
     for indentation.
 
 -   Leading and trailing whitespace between nodes is not preserved (to preserve newlines try using
-    [Experimental Keep Newlines](#option_experimental-keep-newlines)). Similar to
+    [Experimental Keep Newlines](#option---experimental-keep-newlines)). Similar to
     indentation, the upstream YAML library does not capture truly empty nodes.
     Thus, blank lines may be removed between nodes. This will not affect
     multi-line values.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ There are a few options for installing ratchet:
 ## Usage
 
 For more information about available commands and options, run a command with
-`-help` to use detailed usage instructions.
+`-help` to use detailed usage instructions. Also see [CLI Options](#cli-options).
 
 #### Pin
 
@@ -127,6 +127,20 @@ error code when entries are not pinned:
 ```shell
 ./ratchet check workflow.yml
 ```
+
+### CLI Options
+
+Use these options to configure the default behavior of Ratchet.
+
+#### Option - Experimental Keep Newlines
+
+Experimental functionality to enable keeping newlines in the output. Only
+applies to cli commands that modify output.
+
+##### Usage
+
+Enable via environment variable `RATCHET_EXP_KEEP_NEWLINES=true` or
+flag `-experimental-keep-newlines`.
 
 ## Examples
 
@@ -216,7 +230,8 @@ only applies to the line on which it appears.
     capture pre-parsing indentation. Thus, all files will be saved with 2 spaces
     for indentation.
 
--   Leading and trailing whitespace between nodes is not preserved. Similar to
+-   Leading and trailing whitespace between nodes is not preserved (to preserve newlines try using
+    [Experimental Keep Newlines](#option_experimental-keep-newlines)). Similar to
     indentation, the upstream YAML library does not capture truly empty nodes.
     Thus, blank lines may be removed between nodes. This will not affect
     multi-line values.

--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ applies to cli commands that modify output.
 
 ##### Usage
 
-Enable via environment variable `RATCHET_EXP_KEEP_NEWLINES=true` or
-flag `-experimental-keep-newlines`.
+Enable via environment variable `RATCHET_EXP_KEEP_NEWLINES=true`.
 
 ## Examples
 

--- a/command/cmd/gen/main.go
+++ b/command/cmd/gen/main.go
@@ -38,7 +38,7 @@ func realMain() error {
 
 	root := folderRoot()
 	pth := path.Join(root, "command_gen.go")
-	if err := os.WriteFile(pth, w.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(pth, w.Bytes(), 0o644); err != nil {
 		return fmt.Errorf("failed to write generated file: %w", err)
 	}
 

--- a/command/command.go
+++ b/command/command.go
@@ -5,8 +5,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+	"strings"
 
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/myers"
+	"github.com/hexops/gotextdiff/span"
 	"gopkg.in/yaml.v3"
 
 	"github.com/sethvargo/ratchet/internal/atomic"
@@ -146,4 +151,52 @@ func parseYAMLFile(pth string) (m *yaml.Node, retErr error) {
 
 	m, retErr = parseYAML(f)
 	return
+}
+
+func parseFile(pth string) (contents string, retErr error) {
+	f, err := os.Open(pth)
+	if err != nil {
+		retErr = fmt.Errorf("failed to open file: %w", err)
+		return
+	}
+	defer func() {
+		if err := f.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("failed to close file: %w", err)
+		}
+	}()
+	c, retErr := ioutil.ReadAll(f)
+	contents = string(c)
+	return
+}
+
+func removeNewLineChanges(beforeContent string, afterContent string) string {
+	lines := strings.Split(beforeContent, "\n")
+	edits := myers.ComputeEdits(span.URIFromPath("before.txt"), beforeContent, afterContent)
+	unified := gotextdiff.ToUnified("before.txt", "after.txt", beforeContent, edits)
+
+	editedLines := make(map[int]string)
+	for _, h := range unified.Hunks {
+		var deletePositions []int
+		inserts := 0
+		for i, l := range h.Lines {
+			if l.Kind == gotextdiff.Delete && l.Content != "\n" {
+				deletePositions = append(deletePositions, h.FromLine+i-1-inserts)
+			}
+			if l.Kind == gotextdiff.Insert && l.Content != "" {
+				pos := deletePositions[0]
+				deletePositions = deletePositions[1:]
+				editedLines[pos] = strings.TrimSuffix(l.Content, "\n")
+				inserts++
+			}
+		}
+	}
+	var formattedLines []string
+	for i, line := range lines {
+		if editedLine, ok := editedLines[i]; ok {
+			formattedLines = append(formattedLines, editedLine)
+		} else {
+			formattedLines = append(formattedLines, line)
+		}
+	}
+	return strings.Join(formattedLines, "\n")
 }

--- a/command/command.go
+++ b/command/command.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/hexops/gotextdiff"
@@ -52,6 +53,16 @@ func Run(ctx context.Context, args []string) error {
 	}
 
 	return cmd.Run(ctx, args)
+}
+
+func keepNewlinesEnv() bool {
+	value := false
+	if v, ok := os.LookupEnv("RATCHET_EXP_KEEP_NEWLINES"); ok {
+		if t, err := strconv.ParseBool(v); err == nil {
+			value = t
+		}
+	}
+	return value
 }
 
 // extractCommandAndArgs is a helper that pulls the subcommand and arguments.

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -203,6 +203,71 @@ jobs:
         with:
           directories: '${{ inputs.directories }}'
 `
+	yamlD = `
+jobs:
+  init:
+    runs-on:    'ubuntu-latest'
+    outputs:
+      directories: '${{ steps.dirs.outputs.directories }}'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab' # ratchet:actions/checkout@v3
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: 'abcxyz/guardian/.github/actions/directories@52a8396df1c40bde244947c887d2c5dfbd36e4ce' # ratchet:abcxyz/guardian/.github/actions/directories@main
+        with:
+          directories: '${{ inputs.directories }}'
+          thing: |-
+            this is my string
+            it has many lines
+
+            some of them even
+            have new new lines
+`
+	yamlDChanges = `
+jobs:
+  init:
+    runs-on: 'ubuntu-latest'
+    outputs:
+      directories: '${{ steps.dirs.outputs.directories }}'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab' # ratchet:actions/checkout@v3
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: 'abcxyz/guardian/.github/actions/directories@52a8396df1c40bde244947c887d2c5dfbd36e4ce' # ratchet:abcxyz/guardian/.github/actions/directories@main
+        with:
+          directories: '${{ inputs.directories }}'
+          thing: |-
+            this is my string
+            it has many lines
+
+            some of them even
+            have new new lines
+`
+	yamlDChangesFormatted = `
+jobs:
+  init:
+    runs-on: 'ubuntu-latest'
+    outputs:
+      directories: '${{ steps.dirs.outputs.directories }}'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab' # ratchet:actions/checkout@v3
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: 'abcxyz/guardian/.github/actions/directories@52a8396df1c40bde244947c887d2c5dfbd36e4ce' # ratchet:abcxyz/guardian/.github/actions/directories@main
+        with:
+          directories: '${{ inputs.directories }}'
+          thing: |-
+            this is my string
+            it has many lines
+
+            some of them even
+            have new new lines
+`
 )
 
 func Test_removeNewLineChanges(t *testing.T) {
@@ -231,6 +296,12 @@ func Test_removeNewLineChanges(t *testing.T) {
 			yamlBefore: yamlC,
 			yamlAfter:  yamlCChanges,
 			want:       yamlCChangesFormatted,
+		},
+		{
+			name:       "yamlD_multiline_string",
+			yamlBefore: yamlD,
+			yamlAfter:  yamlDChanges,
+			want:       yamlDChangesFormatted,
 		},
 	}
 

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -1,0 +1,143 @@
+package command
+
+import (
+	"reflect"
+	"testing"
+)
+
+const (
+	yamlA = `
+jobs:
+  init:
+    runs-on: 'ubuntu-latest'
+    outputs:
+      directories: '${{ steps.dirs.outputs.directories }}'
+    steps:
+	  - uses: 'actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab' # ratchet:actions/checkout@v3
+
+      - uses: 'actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab' # ratchet:actions/checkout@v3
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: 'abcxyz/guardian/.github/actions/directories@52a8396df1c40bde244947c887d2c5dfbd36e4ce' # ratchet:abcxyz/guardian/.github/actions/directories@main
+        with:
+          directories: '${{ inputs.directories }}'
+`
+	yamlAChanges = `
+jobs:
+  init:
+    runs-on: 'ubuntu-latest'
+    outputs:
+      directories: '${{ steps.dirs.outputs.directories }}'
+    steps:
+	  - uses: 'actions/checkout@9239842384293848238sfsdf823e234234234sds' # ratchet:actions/checkout@v3
+      - uses: 'actions/checkout@9239842384293848238sfsdf823e234234234sds' # ratchet:actions/checkout@v3
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: 'abcxyz/guardian/.github/actions/directories@sdfswdf23423423423423sdfsdfsdfsdfdsfsdf2' # ratchet:abcxyz/guardian/.github/actions/directories@main
+        with:
+          directories: '${{ inputs.directories }}'
+`
+	yamlAChangesFormatted = `
+jobs:
+  init:
+    runs-on: 'ubuntu-latest'
+    outputs:
+      directories: '${{ steps.dirs.outputs.directories }}'
+    steps:
+	  - uses: 'actions/checkout@9239842384293848238sfsdf823e234234234sds' # ratchet:actions/checkout@v3
+
+      - uses: 'actions/checkout@9239842384293848238sfsdf823e234234234sds' # ratchet:actions/checkout@v3
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: 'abcxyz/guardian/.github/actions/directories@sdfswdf23423423423423sdfsdfsdfsdfdsfsdf2' # ratchet:abcxyz/guardian/.github/actions/directories@main
+        with:
+          directories: '${{ inputs.directories }}'
+`
+	yamlB = `
+jobs:
+  init:
+    runs-on:  'ubuntu-latest'
+    outputs:
+      directories: '${{ steps.dirs.outputs.directories }}'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab' # ratchet:actions/checkout@v3
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: 'abcxyz/guardian/.github/actions/directories@52a8396df1c40bde244947c887d2c5dfbd36e4ce' # ratchet:abcxyz/guardian/.github/actions/directories@main
+        with:
+          directories: '${{ inputs.directories }}'
+`
+	yamlBChanges = `
+jobs:
+  init:
+    runs-on: 'ubuntu-latest'
+    outputs:
+      directories: '${{ steps.dirs.outputs.directories }}'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@9239842384293848238sfsdf823e234234234sds' # ratchet:actions/checkout@v3
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: 'abcxyz/guardian/.github/actions/directories@sdfswdf23423423423423sdfsdfsdfsdfdsfsdf2' # ratchet:abcxyz/guardian/.github/actions/directories@main
+        with:
+          directories: '${{ inputs.directories }}'
+`
+	yamlBChangesFormatted = `
+jobs:
+  init:
+    runs-on: 'ubuntu-latest'
+    outputs:
+      directories: '${{ steps.dirs.outputs.directories }}'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@9239842384293848238sfsdf823e234234234sds' # ratchet:actions/checkout@v3
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: 'abcxyz/guardian/.github/actions/directories@sdfswdf23423423423423sdfsdfsdfsdfdsfsdf2' # ratchet:abcxyz/guardian/.github/actions/directories@main
+        with:
+          directories: '${{ inputs.directories }}'
+`
+)
+
+func Test_removeNewLineChanges(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		yamlBefore string
+		yamlAfter  string
+		want       string
+	}{
+		{
+			name:       "yamlA_multiple_empty_lines",
+			yamlBefore: yamlA,
+			yamlAfter:  yamlAChanges,
+			want:       yamlAChangesFormatted,
+		},
+		{
+			name:       "yamlB_single_empty_line",
+			yamlBefore: yamlB,
+			yamlAfter:  yamlBChanges,
+			want:       yamlBChangesFormatted,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := removeNewLineChanges(tc.yamlBefore, tc.yamlAfter)
+
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("expected %s to be %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -102,6 +102,107 @@ jobs:
         with:
           directories: '${{ inputs.directories }}'
 `
+	yamlC = `
+jobs:
+  init:
+    runs-on:    'ubuntu-latest'
+    outputs:
+      directories: '${{ steps.dirs.outputs.directories }}'
+    steps:
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - name: 'Checkout'
+        uses: 'actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab' # ratchet:actions/checkout@v3
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: 'abcxyz/guardian/.github/actions/directories@52a8396df1c40bde244947c887d2c5dfbd36e4ce' # ratchet:abcxyz/guardian/.github/actions/directories@main
+        with:
+          directories: '${{ inputs.directories }}'
+`
+	yamlCChanges = `
+jobs:
+  init:
+    runs-on: 'ubuntu-latest'
+    outputs:
+      directories: '${{ steps.dirs.outputs.directories }}'
+    steps:
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - name: 'Checkout'
+        uses: 'actions/checkout@9239842384293848238sfsdf823e234234234sds' # ratchet:actions/checkout@v3
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: 'abcxyz/guardian/.github/actions/directories@sdfswdf23423423423423sdfsdfsdfsdfdsfsdf2' # ratchet:abcxyz/guardian/.github/actions/directories@main
+        with:
+          directories: '${{ inputs.directories }}'
+`
+	yamlCChangesFormatted = `
+jobs:
+  init:
+    runs-on: 'ubuntu-latest'
+    outputs:
+      directories: '${{ steps.dirs.outputs.directories }}'
+    steps:
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - id : 'print'
+        runs: 'echo "hello"'
+      - name: 'Checkout'
+        uses: 'actions/checkout@9239842384293848238sfsdf823e234234234sds' # ratchet:actions/checkout@v3
+
+      - name: 'Guardian Directories'
+        id: 'dirs'
+        uses: 'abcxyz/guardian/.github/actions/directories@sdfswdf23423423423423sdfsdfsdfsdfdsfsdf2' # ratchet:abcxyz/guardian/.github/actions/directories@main
+        with:
+          directories: '${{ inputs.directories }}'
+`
 )
 
 func Test_removeNewLineChanges(t *testing.T) {
@@ -124,6 +225,12 @@ func Test_removeNewLineChanges(t *testing.T) {
 			yamlBefore: yamlB,
 			yamlAfter:  yamlBChanges,
 			want:       yamlBChangesFormatted,
+		},
+		{
+			name:       "yamlC_long_unchanged_section",
+			yamlBefore: yamlC,
+			yamlAfter:  yamlCChanges,
+			want:       yamlCChangesFormatted,
 		},
 	}
 

--- a/command/pin.go
+++ b/command/pin.go
@@ -35,10 +35,9 @@ FLAGS
 `
 
 type PinCommand struct {
-	flagConcurrency              int64
-	flagParser                   string
-	flagOut                      string
-	flagExperimentalKeepNewlines bool
+	flagConcurrency int64
+	flagParser      string
+	flagOut         string
 }
 
 func (c *PinCommand) Desc() string {
@@ -56,7 +55,6 @@ func (c *PinCommand) Flags() *flag.FlagSet {
 		"maximum number of concurrent resolutions")
 	f.StringVar(&c.flagParser, "parser", "actions", "parser to use")
 	f.StringVar(&c.flagOut, "out", "", "output path (defaults to input file)")
-	f.BoolVar(&c.flagExperimentalKeepNewlines, "experimental-keep-newlines", keepNewlinesEnv(), "")
 
 	return f
 }
@@ -108,7 +106,7 @@ func (c *PinCommand) Run(ctx context.Context, originalArgs []string) error {
 		return fmt.Errorf("failed to save %s: %w", outFile, err)
 	}
 
-	if !c.flagExperimentalKeepNewlines {
+	if !keepNewlinesEnv() {
 		return nil
 	}
 

--- a/command/pin.go
+++ b/command/pin.go
@@ -35,9 +35,10 @@ FLAGS
 `
 
 type PinCommand struct {
-	flagConcurrency int64
-	flagParser      string
-	flagOut         string
+	flagConcurrency                int64
+	flagParser                     string
+	flagOut                        string
+	flagExperimentalFormatNewlines bool
 }
 
 func (c *PinCommand) Desc() string {
@@ -55,6 +56,7 @@ func (c *PinCommand) Flags() *flag.FlagSet {
 		"maximum number of concurrent resolutions")
 	f.StringVar(&c.flagParser, "parser", "actions", "parser to use")
 	f.StringVar(&c.flagOut, "out", "", "output path (defaults to input file)")
+	f.BoolVar(&c.flagExperimentalFormatNewlines, "experimental-format-newlines", false, "whether or not to undo removing newlines")
 
 	return f
 }
@@ -104,6 +106,10 @@ func (c *PinCommand) Run(ctx context.Context, originalArgs []string) error {
 
 	if err := writeYAMLFile(inFile, outFile, m); err != nil {
 		return fmt.Errorf("failed to save %s: %w", outFile, err)
+	}
+
+	if !c.flagExperimentalFormatNewlines {
+		return nil
 	}
 
 	editedContent, err := parseFile(outFile)

--- a/command/pin.go
+++ b/command/pin.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/sethvargo/ratchet/internal/atomic"
 	"github.com/sethvargo/ratchet/internal/concurrency"
 	"github.com/sethvargo/ratchet/parser"
 	"github.com/sethvargo/ratchet/resolver"
@@ -71,6 +72,12 @@ func (c *PinCommand) Run(ctx context.Context, originalArgs []string) error {
 	}
 
 	inFile := args[0]
+
+	uneditedContent, err := parseFile(inFile)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s: %w", inFile, err)
+	}
+
 	m, err := parseYAMLFile(inFile)
 	if err != nil {
 		return fmt.Errorf("failed to parse %s: %w", inFile, err)
@@ -94,8 +101,19 @@ func (c *PinCommand) Run(ctx context.Context, originalArgs []string) error {
 	if outFile == "" {
 		outFile = inFile
 	}
+
 	if err := writeYAMLFile(inFile, outFile, m); err != nil {
 		return fmt.Errorf("failed to save %s: %w", outFile, err)
+	}
+
+	editedContent, err := parseFile(outFile)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s: %w", outFile, err)
+	}
+
+	final := removeNewLineChanges(uneditedContent, editedContent)
+	if err := atomic.Write(inFile, outFile, strings.NewReader(final)); err != nil {
+		return fmt.Errorf("failed to save file %s: %w", outFile, err)
 	}
 
 	return nil

--- a/command/pin.go
+++ b/command/pin.go
@@ -35,10 +35,10 @@ FLAGS
 `
 
 type PinCommand struct {
-	flagConcurrency                int64
-	flagParser                     string
-	flagOut                        string
-	flagExperimentalFormatNewlines bool
+	flagConcurrency              int64
+	flagParser                   string
+	flagOut                      string
+	flagExperimentalKeepNewlines bool
 }
 
 func (c *PinCommand) Desc() string {
@@ -56,7 +56,7 @@ func (c *PinCommand) Flags() *flag.FlagSet {
 		"maximum number of concurrent resolutions")
 	f.StringVar(&c.flagParser, "parser", "actions", "parser to use")
 	f.StringVar(&c.flagOut, "out", "", "output path (defaults to input file)")
-	f.BoolVar(&c.flagExperimentalFormatNewlines, "experimental-format-newlines", false, "whether or not to undo removing newlines")
+	f.BoolVar(&c.flagExperimentalKeepNewlines, "experimental-keep-newlines", keepNewlinesEnv(), "")
 
 	return f
 }
@@ -108,7 +108,7 @@ func (c *PinCommand) Run(ctx context.Context, originalArgs []string) error {
 		return fmt.Errorf("failed to save %s: %w", outFile, err)
 	}
 
-	if !c.flagExperimentalFormatNewlines {
+	if !c.flagExperimentalKeepNewlines {
 		return nil
 	}
 

--- a/command/unpin.go
+++ b/command/unpin.go
@@ -34,8 +34,7 @@ FLAGS
 `
 
 type UnpinCommand struct {
-	flagOut                      string
-	flagExperimentalKeepNewlines bool
+	flagOut string
 }
 
 func (c *UnpinCommand) Desc() string {
@@ -50,7 +49,6 @@ func (c *UnpinCommand) Flags() *flag.FlagSet {
 	}
 
 	f.StringVar(&c.flagOut, "out", "", "output path (defaults to input file)")
-	f.BoolVar(&c.flagExperimentalKeepNewlines, "experimental-keep-newlines", keepNewlinesEnv(), "")
 
 	return f
 }
@@ -90,7 +88,7 @@ func (c *UnpinCommand) Run(ctx context.Context, originalArgs []string) error {
 		return fmt.Errorf("failed to save %s: %w", outFile, err)
 	}
 
-	if !c.flagExperimentalKeepNewlines {
+	if !keepNewlinesEnv() {
 		return nil
 	}
 

--- a/command/unpin.go
+++ b/command/unpin.go
@@ -34,8 +34,8 @@ FLAGS
 `
 
 type UnpinCommand struct {
-	flagOut                        string
-	flagExperimentalFormatNewlines bool
+	flagOut                      string
+	flagExperimentalKeepNewlines bool
 }
 
 func (c *UnpinCommand) Desc() string {
@@ -50,7 +50,7 @@ func (c *UnpinCommand) Flags() *flag.FlagSet {
 	}
 
 	f.StringVar(&c.flagOut, "out", "", "output path (defaults to input file)")
-	f.BoolVar(&c.flagExperimentalFormatNewlines, "experimental-format-newlines", false, "whether or not to undo removing newlines")
+	f.BoolVar(&c.flagExperimentalKeepNewlines, "experimental-keep-newlines", keepNewlinesEnv(), "")
 
 	return f
 }
@@ -90,7 +90,7 @@ func (c *UnpinCommand) Run(ctx context.Context, originalArgs []string) error {
 		return fmt.Errorf("failed to save %s: %w", outFile, err)
 	}
 
-	if !c.flagExperimentalFormatNewlines {
+	if !c.flagExperimentalKeepNewlines {
 		return nil
 	}
 

--- a/command/unpin.go
+++ b/command/unpin.go
@@ -34,7 +34,8 @@ FLAGS
 `
 
 type UnpinCommand struct {
-	flagOut string
+	flagOut                        string
+	flagExperimentalFormatNewlines bool
 }
 
 func (c *UnpinCommand) Desc() string {
@@ -49,6 +50,7 @@ func (c *UnpinCommand) Flags() *flag.FlagSet {
 	}
 
 	f.StringVar(&c.flagOut, "out", "", "output path (defaults to input file)")
+	f.BoolVar(&c.flagExperimentalFormatNewlines, "experimental-format-newlines", false, "whether or not to undo removing newlines")
 
 	return f
 }
@@ -86,6 +88,10 @@ func (c *UnpinCommand) Run(ctx context.Context, originalArgs []string) error {
 	}
 	if err := writeYAMLFile(inFile, outFile, m); err != nil {
 		return fmt.Errorf("failed to save %s: %w", outFile, err)
+	}
+
+	if !c.flagExperimentalFormatNewlines {
+		return nil
 	}
 
 	editedContent, err := parseFile(outFile)

--- a/command/unpin.go
+++ b/command/unpin.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/sethvargo/ratchet/internal/atomic"
 	"github.com/sethvargo/ratchet/parser"
 )
 
@@ -65,6 +66,11 @@ func (c *UnpinCommand) Run(ctx context.Context, originalArgs []string) error {
 	}
 
 	inFile := args[0]
+	uneditedContent, err := parseFile(inFile)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s: %w", inFile, err)
+	}
+
 	m, err := parseYAMLFile(inFile)
 	if err != nil {
 		return fmt.Errorf("failed to parse %s: %w", inFile, err)
@@ -80,6 +86,16 @@ func (c *UnpinCommand) Run(ctx context.Context, originalArgs []string) error {
 	}
 	if err := writeYAMLFile(inFile, outFile, m); err != nil {
 		return fmt.Errorf("failed to save %s: %w", outFile, err)
+	}
+
+	editedContent, err := parseFile(outFile)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s: %w", outFile, err)
+	}
+
+	final := removeNewLineChanges(uneditedContent, editedContent)
+	if err := atomic.Write(inFile, outFile, strings.NewReader(final)); err != nil {
+		return fmt.Errorf("failed to save file %s: %w", outFile, err)
 	}
 
 	return nil

--- a/command/update.go
+++ b/command/update.go
@@ -97,6 +97,10 @@ func (c *UpdateCommand) Run(ctx context.Context, originalArgs []string) error {
 		return fmt.Errorf("failed to save %s: %w", outFile, err)
 	}
 
+	if !c.PinCommand.flagExperimentalFormatNewlines {
+		return nil
+	}
+
 	editedContent, err := parseFile(outFile)
 	if err != nil {
 		return fmt.Errorf("failed to parse %s: %w", outFile, err)

--- a/command/update.go
+++ b/command/update.go
@@ -97,7 +97,7 @@ func (c *UpdateCommand) Run(ctx context.Context, originalArgs []string) error {
 		return fmt.Errorf("failed to save %s: %w", outFile, err)
 	}
 
-	if !c.PinCommand.flagExperimentalKeepNewlines {
+	if !keepNewlinesEnv() {
 		return nil
 	}
 

--- a/command/update.go
+++ b/command/update.go
@@ -97,7 +97,7 @@ func (c *UpdateCommand) Run(ctx context.Context, originalArgs []string) error {
 		return fmt.Errorf("failed to save %s: %w", outFile, err)
 	}
 
-	if !c.PinCommand.flagExperimentalFormatNewlines {
+	if !c.PinCommand.flagExperimentalKeepNewlines {
 		return nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/go-containerregistry v0.14.0
 	github.com/google/go-github/v51 v51.0.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hexops/gotextdiff v1.0.3
 	golang.org/x/oauth2 v0.7.0
 	golang.org/x/sync v0.1.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/klauspost/compress v1.16.3 h1:XuJt9zzcnaz6a16/OU53ZjWp/v7/42WcR5t2a0PcNQY=
 github.com/klauspost/compress v1.16.3/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/internal/atomic/atomic.go
+++ b/internal/atomic/atomic.go
@@ -10,11 +10,11 @@ import (
 const (
 	// DefaultFilePerm are the default file permission to use when the permissions
 	// cannot be determined from the existing file.
-	DefaultFilePerm os.FileMode = 0644
+	DefaultFilePerm os.FileMode = 0o644
 
 	// DefaultFolderPerm is the default permission to use when creating parent
 	// directories, if they do not already exist.
-	DefaultFolderPerm os.FileMode = 0755
+	DefaultFolderPerm os.FileMode = 0o755
 )
 
 // AtomicWrite accepts a destination path and an reader. It copies the contents

--- a/parser/gitlabci.go
+++ b/parser/gitlabci.go
@@ -17,7 +17,7 @@ func (C *GitLabCI) Parse(m *yaml.Node) (*RefsList, error) {
 	var imageRef *yaml.Node
 
 	// GitLab CI global top level keywords
-	var globalKeywords = map[string]struct{}{
+	globalKeywords := map[string]struct{}{
 		"default":   {},
 		"include":   {},
 		"stages":    {},
@@ -58,7 +58,6 @@ func (C *GitLabCI) Parse(m *yaml.Node) (*RefsList, error) {
 
 					// match image reference with name key
 					if image.Kind == yaml.MappingNode {
-
 						for j, nameRef := range image.Content {
 							if nameRef.Value == "name" {
 								imageRef = image.Content[j+1]

--- a/parser/gitlabci_test.go
+++ b/parser/gitlabci_test.go
@@ -105,7 +105,6 @@ job2:
 			m := helperStringToYAML(t, tc.in)
 
 			refs, err := new(GitLabCI).Parse(m)
-
 			if err != nil {
 				fmt.Println(refs)
 				t.Fatal(err)


### PR DESCRIPTION
This change introduces a new flag `flagExperimentalFormatNewlines` for the `pin`, `update`, and `unpin` commands. This flag enables a feature to undo formatting changes that resulted in removed newlines.