### PR TITLE
Support multiple files as inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,16 +237,5 @@ only applies to the line on which it appears.
           - uses: 'actions/checkout@v${{ matrix.version }}'
     ```
 
-## Experiments
-
-Use these options to configure the default behavior of Ratchet.
-
-### Experiment: Keep Newlines
-
-Experimental functionality to enable keeping newlines in the output. This only
-applies to cli commands that modify output. As of v0.5.0, this functionality is
-enabled by default. To disable it, set the environment variable
-`RATCHET_EXP_KEEP_NEWLINES=false`.
-
 [containers]: https://github.com/sethvargo/ratchet/pkgs/container/ratchet
 [releases]: https://github.com/sethvargo/ratchet/releases

--- a/command/cmd/gen/main.go
+++ b/command/cmd/gen/main.go
@@ -38,7 +38,7 @@ func realMain() error {
 
 	root := folderRoot()
 	pth := path.Join(root, "command_gen.go")
-	if err := os.WriteFile(pth, w.Bytes(), 0o644); err != nil {
+	if err := os.WriteFile(pth, w.Bytes(), 0o600); err != nil {
 		return fmt.Errorf("failed to write generated file: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -11,16 +11,17 @@ import (
 )
 
 func main() {
-	if err := realMain(); err != nil {
+	ctx, done := signal.NotifyContext(context.Background(),
+		syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	if err := realMain(ctx); err != nil {
+		done()
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }
 
-func realMain() error {
-	ctx, done := signal.NotifyContext(context.Background(),
-		syscall.SIGINT, syscall.SIGTERM)
-	defer done()
-
+func realMain(ctx context.Context) error {
 	return command.Run(ctx, os.Args[1:])
 }

--- a/parser/actions.go
+++ b/parser/actions.go
@@ -7,26 +7,35 @@ import (
 	// Using banydonk/yaml instead of the default yaml pkg because the default
 	// pkg incorrectly escapes unicode. https://github.com/go-yaml/yaml/issues/737
 	"github.com/braydonk/yaml"
-
 	"github.com/sethvargo/ratchet/resolver"
 )
 
 type Actions struct{}
 
-// Parse pulls the GitHub Actions refs from the document.
-func (a *Actions) Parse(m *yaml.Node) (*RefsList, error) {
+// Parse pulls the GitHub Actions refs from the documents.
+func (a *Actions) Parse(nodes []*yaml.Node) (*RefsList, error) {
 	var refs RefsList
 
-	if m == nil {
-		return nil, nil
+	for i, node := range nodes {
+		if err := a.parseOne(&refs, node); err != nil {
+			return nil, fmt.Errorf("failed to parse node %d: %w", i, err)
+		}
 	}
 
-	if m.Kind != yaml.DocumentNode {
-		return nil, fmt.Errorf("expected document node, got %v", m.Kind)
+	return &refs, nil
+}
+
+func (a *Actions) parseOne(refs *RefsList, node *yaml.Node) error {
+	if node == nil {
+		return nil
+	}
+
+	if node.Kind != yaml.DocumentNode {
+		return fmt.Errorf("expected document node, got %v", node.Kind)
 	}
 
 	// Top-level object map
-	for _, docMap := range m.Content {
+	for _, docMap := range node.Content {
 		if docMap.Kind != yaml.MappingNode {
 			continue
 		}
@@ -174,5 +183,5 @@ func (a *Actions) Parse(m *yaml.Node) (*RefsList, error) {
 		}
 	}
 
-	return &refs, nil
+	return nil
 }

--- a/parser/actions_test.go
+++ b/parser/actions_test.go
@@ -3,6 +3,8 @@ package parser
 import (
 	"reflect"
 	"testing"
+
+	"github.com/braydonk/yaml"
 )
 
 func TestActions_Parse(t *testing.T) {
@@ -99,7 +101,7 @@ runs:
 
 			m := helperStringToYAML(t, tc.in)
 
-			refs, err := new(Actions).Parse(m)
+			refs, err := new(Actions).Parse([]*yaml.Node{m})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/parser/circleci_test.go
+++ b/parser/circleci_test.go
@@ -3,6 +3,8 @@ package parser
 import (
 	"reflect"
 	"testing"
+
+	"github.com/braydonk/yaml"
 )
 
 func TestCircleCI_Parse(t *testing.T) {
@@ -56,7 +58,7 @@ jobs:
 
 			m := helperStringToYAML(t, tc.in)
 
-			refs, err := new(CircleCI).Parse(m)
+			refs, err := new(CircleCI).Parse([]*yaml.Node{m})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/parser/cloudbuild_test.go
+++ b/parser/cloudbuild_test.go
@@ -3,6 +3,8 @@ package parser
 import (
 	"reflect"
 	"testing"
+
+	"github.com/braydonk/yaml"
 )
 
 func TestCloudBuild_Parse(t *testing.T) {
@@ -42,7 +44,7 @@ steps:
 
 			m := helperStringToYAML(t, tc.in)
 
-			refs, err := new(CloudBuild).Parse(m)
+			refs, err := new(CloudBuild).Parse([]*yaml.Node{m})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/parser/drone_test.go
+++ b/parser/drone_test.go
@@ -3,6 +3,8 @@ package parser
 import (
 	"reflect"
 	"testing"
+
+	"github.com/braydonk/yaml"
 )
 
 func TestDrone_Parse(t *testing.T) {
@@ -26,7 +28,7 @@ jobs:
 steps:
   - name: git
     image: alpine/git
-  
+
   - name: test
     image: mysql
 `,
@@ -45,7 +47,7 @@ steps:
 
 			m := helperStringToYAML(t, tc.in)
 
-			refs, err := new(Drone).Parse(m)
+			refs, err := new(Drone).Parse([]*yaml.Node{m})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/parser/gitlabci_test.go
+++ b/parser/gitlabci_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/braydonk/yaml"
 )
 
 func TestGitLabCI_Parse(t *testing.T) {
@@ -104,7 +106,7 @@ job2:
 
 			m := helperStringToYAML(t, tc.in)
 
-			refs, err := new(GitLabCI).Parse(m)
+			refs, err := new(GitLabCI).Parse([]*yaml.Node{m})
 			if err != nil {
 				fmt.Println(refs)
 				t.Fatal(err)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -9,7 +9,6 @@ import (
 	// Using banydonk/yaml instead of the default yaml pkg because the default
 	// pkg incorrectly escapes unicode. https://github.com/go-yaml/yaml/issues/737
 	"github.com/braydonk/yaml"
-
 	"github.com/sethvargo/ratchet/resolver"
 )
 
@@ -69,7 +68,7 @@ jobs:
 
 			m := helperStringToYAML(t, tc.in)
 
-			if err := Check(ctx, par, m); err != nil {
+			if err := Check(ctx, par, []*yaml.Node{m}); err != nil {
 				if tc.err == "" {
 					t.Fatal(err)
 				} else {
@@ -211,7 +210,7 @@ jobs:
 
 			m := helperStringToYAML(t, tc.in)
 
-			if err := Pin(ctx, res, par, m, 2); err != nil {
+			if err := Pin(ctx, res, par, []*yaml.Node{m}, 2); err != nil {
 				if tc.err == "" {
 					t.Fatal(err)
 				} else {
@@ -234,6 +233,8 @@ jobs:
 
 func TestUnpin(t *testing.T) {
 	t.Parallel()
+
+	ctx := context.Background()
 
 	cases := []struct {
 		name string
@@ -283,7 +284,7 @@ func TestUnpin(t *testing.T) {
 
 			m := helperStringToYAML(t, tc.in)
 
-			if err := Unpin(m); err != nil {
+			if err := Unpin(ctx, []*yaml.Node{m}); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
This is a refactor to enable Ratchet to support multiple files in a single run. All files are parsed once (to limit upstream API calls) and then updated in serial.

Closes https://github.com/sethvargo/ratchet/pull/29