### PR TITLE
extend gitlabci parser to support services images

### DIFF
--- a/parser/gitlabci.go
+++ b/parser/gitlabci.go
@@ -80,6 +80,22 @@ func (c *GitLabCI) parseOne(refs *RefsList, m *yaml.Node) error {
 
 					ref := resolver.NormalizeContainerRef(imageRef.Value)
 					refs.Add(ref, imageRef)
+				} else if property.Value == "services" {
+					node := job.Content[k+1]
+					for _, service := range node.Content {
+						if service.Kind == yaml.MappingNode {
+							for j, nameRef := range service.Content {
+								if nameRef.Value == "name" {
+									imageRef = service.Content[j+1]
+									break
+								}
+							}
+						} else {
+							imageRef = service
+						}
+						ref := resolver.NormalizeContainerRef(imageRef.Value)
+						refs.Add(ref, imageRef)
+					}
 				}
 			}
 		}

--- a/parser/gitlabci_test.go
+++ b/parser/gitlabci_test.go
@@ -96,8 +96,48 @@ job2:
 				"container://python",
 			},
 		},
-	}
+		{
+			name: "jobs_with_services",
+			in: `
+.test:base:
+  stage: test
+  image: python
+  retry:
+    max: 1
+  variables:
+    VAR1: true
+  script:
+    - test command
 
+job:
+  extends:
+    - .test:base
+  image: node:12
+  services:
+    - postgres:14.3
+    - docker:24.0.5-dind
+    - name: selenium/standalone-firefox:latest
+      alias: firefox
+  stage: test
+  script:
+    - test command
+
+job2:
+  image: gcr.io/project/image:tag
+  stage: test
+  script:
+    - test command
+`,
+			exp: []string{
+				"container://docker:24.0.5-dind",
+				"container://gcr.io/project/image:tag",
+				"container://node:12",
+				"container://postgres:14.3",
+				"container://python",
+				"container://selenium/standalone-firefox:latest",
+			},
+		},
+	}
 	for _, tc := range cases {
 		tc := tc
 


### PR DESCRIPTION
Gitlab allows users to run multiple containers within a container with the services feature: https://docs.gitlab.com/ee/ci/services/

This pull request extends the gitlabci parser to find all of the images withing a services: definition.