### PR TITLE
docs(readme): note nix package in Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ There are a few options for installing ratchet:
 
 -   As a single-static binary from the [releases page][releases].
 -   As a container image from the [container registry][containers].
+-   Via nix:
+
+    ```sh
+    nix run 'github:NixOS/nixpkgs/nixpkgs-unstable#ratchet' -- --help
+    ```
+
+    Note this option is community supported and may not be the latest
+    available version.
+
 -   Compiled from source yourself. Note this option is not supported.
 
 


### PR DESCRIPTION
Following up on #83, this PR documents the ability to use and/or install ratchet via nix. It is currently available on ~nixpkgs/master, but will become available on~ nixpkgs/nixpkgs-unstable ~shortly~.