### PR TITLE
feat: auto detect indentation size

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,10 +254,6 @@ only applies to the line on which it appears.
 
 ## Known issues
 
--   Indentation is always set to 2 spaces. The upstream YAML library does not
-    capture pre-parsing indentation. Thus, all files will be saved with 2 spaces
-    for indentation.
-
 -   Does not support resolving values in anchors or aliases. This is technically
     possible, but most CI systems also don't support these advanced YAML
     features.

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -196,6 +196,22 @@ test-code-job1:
 `,
 			want: []int{6},
 		},
+		{
+			name: "has_indent_of_4",
+			yaml: `this:
+    is: |-
+        a multiline
+
+        string that
+        spans lines
+
+    that:
+        has: |-
+            other multline
+            literal scalars
+`,
+			want: []int{6},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Automatically detects indent by computing the median of the indentation deltas in the provided string yaml content.