### PR TITLE
fix: Preserve YAML formatting by adding preprocessing for trailing whitespace and multiline nodes

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -159,8 +159,14 @@ func loadYAMLFiles(fsys fs.FS, paths []string) (loadResults, error) {
 			return nil, fmt.Errorf("failed to read file %s: %w", pth, err)
 		}
 
+		// Preprocess the YAML content
+		cleanedContents, err := preprocessYAML(contents)
+		if err != nil {
+			return nil, fmt.Errorf("failed to preprocess YAML content for %s: %w", pth, err)
+		}
+
 		var node yaml.Node
-		dec := yaml.NewDecoder(bytes.NewReader(contents))
+		dec := yaml.NewDecoder(bytes.NewReader(cleanedContents))
 		dec.SetScanBlockScalarAsLiteral(true)
 		if err := dec.Decode(&node); err != nil {
 			return nil, fmt.Errorf("failed to parse yaml for %s: %w", pth, err)
@@ -231,6 +237,18 @@ func computeNewlineTargets(before, after string) []int {
 	}
 
 	return result
+}
+
+func preprocessYAML(content []byte) ([]byte, error) {
+	var cleaned []string
+	lines := strings.Split(string(content), "\n")
+
+	for _, line := range lines {
+		cleanedLine := strings.TrimRight(line, " \t")
+		cleaned = append(cleaned, cleanedLine)
+	}
+
+	return []byte(strings.Join(cleaned, "\n")), nil
 }
 
 func processMultilineNodes(node *yaml.Node) {

--- a/command/command.go
+++ b/command/command.go
@@ -115,6 +115,9 @@ type loadResult struct {
 }
 
 func (r *loadResult) marshalYAML() (string, error) {
+	// Process the node tree to ensure multiline strings use LiteralStyle
+	processMultilineNodes(r.node)
+
 	contents, err := marshalYAML(r.node)
 	if err != nil {
 		return "", err
@@ -228,4 +231,20 @@ func computeNewlineTargets(before, after string) []int {
 	}
 
 	return result
+}
+
+func processMultilineNodes(node *yaml.Node) {
+	if node == nil {
+		return
+	}
+
+	// Check if the node is a scalar and contains newlines
+	if node.Kind == yaml.ScalarNode && strings.Contains(node.Value, "\n") {
+		node.Style = yaml.LiteralStyle // Use '|' for block scalars
+	}
+
+	// Recursively process child nodes if applicable
+	for _, child := range node.Content {
+		processMultilineNodes(child)
+	}
 }

--- a/command/command.go
+++ b/command/command.go
@@ -258,7 +258,10 @@ func processMultilineNodes(node *yaml.Node) {
 
 	// Check if the node is a scalar and contains newlines
 	if node.Kind == yaml.ScalarNode && strings.Contains(node.Value, "\n") {
-		node.Style = yaml.LiteralStyle // Use '|' for block scalars
+		if node.Style != yaml.FoldedStyle && node.Style != yaml.LiteralStyle {
+			// Default to LiteralStyle if no style is set, but preserve existing style
+			node.Style = yaml.LiteralStyle
+		}
 	}
 
 	// Recursively process child nodes if applicable

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -15,19 +15,20 @@ func Test_loadYAMLFiles(t *testing.T) {
 	fsys := os.DirFS("../testdata")
 
 	cases := map[string]string{
-		"a.yml":                   "a.golden.yml",
-		"b.yml":                   "b.golden.yml",
-		"c.yml":                   "",
-		"circleci.yml":            "",
-		"cloudbuild.yml":          "",
-		"docker.yml":              "",
-		"drone.yml":               "",
-		"github-crazy-indent.yml": "github.yml",
-		"github-issue-80.yml":     "",
-		"github.yml":              "",
-		"gitlabci.yml":            "",
-		"no-trailing-newline.yml": "no-trailing-newline.golden.yml",
-		"tekton.yml":              "",
+		"a.yml":                    "a.golden.yml",
+		"b.yml":                    "b.golden.yml",
+		"c.yml":                    "",
+		"circleci.yml":             "",
+		"cloudbuild.yml":           "",
+		"docker.yml":               "",
+		"drone.yml":                "",
+		"github-crazy-indent.yml":  "github.yml",
+		"github-issue-80.yml":      "",
+		"github.yml":               "",
+		"gitlabci.yml":             "",
+		"improperly_formatted.yml": "improperly_formatted.golden.yml",
+		"no-trailing-newline.yml":  "no-trailing-newline.golden.yml",
+		"tekton.yml":               "",
 	}
 
 	for input, expected := range cases {

--- a/testdata/improperly_formatted.golden.yml
+++ b/testdata/improperly_formatted.golden.yml
@@ -1,0 +1,14 @@
+name: "Improper Formatting Test"
+description: "Test for improper formatting"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Execute Test
+      run: |
+        echo "Starting tests..."
+
+        echo "Running test suite..."
+        npm test
+
+        echo "Tests complete."

--- a/testdata/improperly_formatted.yml
+++ b/testdata/improperly_formatted.yml
@@ -1,0 +1,14 @@
+name: "Improper Formatting Test"
+description: "Test for improper formatting"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Execute Test
+      run: |
+        echo "Starting tests..."      
+        
+        echo "Running test suite..."  
+        npm test        
+
+        echo "Tests complete."      


### PR DESCRIPTION
**The Issue**
In certain niche cases, `ratchet` fails to preserve formatting for multiline `run:` blocks.
This issue occurs when the input YAML file contains hidden formatting anomalies such as:
- Trailing whitespace
- Empty lines with spaces

These anomalies interfere with the YAML marshaller, causing it to serialise multiline strings as single-line strings with escaped newlines. This results in reduced readability and inconsistent output format.

**The Fix**
This PR introduces a preprocessing step to clean YAML files before parsing. Specifically:
- Trailing whitespace is removed from all lines
- Empty lines with spaces are normalised to be truly empty.

This ensures that the YAML parser receives a clean, consistent file for processing.

Additionally, the `processMultilineNodes` function ensures that multiline scalar nodes (eg. `run:` blocks with newlines) are explicitly set to use `LiteralStyle`, preserving their formatting during serialisation.

**Testing**
This fix was validated by:
1. Testing YAML files with:
    - Multiline `run:` blocks containing special characters, variables, and command substitutions.
    - Trailing spaces and whitespace-only lines.
2. Confirming that the output:
    - Retains proper block scalar formatting for multiline strings.
    - Produces consistent, readable YAML even with formatting anomalies.

**Impact**
This fix ensures proper formatting of YAML files without requiring manual intervention.
Previously, the issue could be resolved by preprocessing files with:
```bash
perl -pi -e 's/[ \t]+$//' <file>
```

Now, the preprocessing is performed natively within the too, eliminating the need for external commands or tools.