### PR TITLE
Refactor internals to keep track of filenames

### DIFF
--- a/command/check.go
+++ b/command/check.go
@@ -60,12 +60,10 @@ func (c *CheckCommand) Run(ctx context.Context, originalArgs []string) error {
 		return err
 	}
 
-	fsys := os.DirFS(".")
-
-	files, err := loadYAMLFiles(fsys, args)
+	loadResult, err := loadYAMLFiles(os.DirFS("."), args)
 	if err != nil {
 		return err
 	}
 
-	return parser.Check(ctx, par, files.nodes())
+	return parser.Check(ctx, par, loadResult.nodes())
 }

--- a/command/cmd/gen/main.go
+++ b/command/cmd/gen/main.go
@@ -56,9 +56,19 @@ func folderRoot() string {
 func buildTopLevelHelp() string {
 	var w strings.Builder
 
+	commands := make(map[string]command.Command, len(command.Commands))
+	for name, command := range command.Commands {
+		// Ignore hidden commands
+		if _, ok := command.(interface{ Hidden() }); ok {
+			continue
+		}
+
+		commands[name] = command
+	}
+
 	longest := 0
-	names := make([]string, 0, len(command.Commands))
-	for name := range command.Commands {
+	names := make([]string, 0, len(commands))
+	for name := range commands {
 		names = append(names, name)
 		if l := len(name); l > longest {
 			longest = l

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -31,25 +31,23 @@ func Test_loadYAMLFiles(t *testing.T) {
 	}
 
 	for input, expected := range cases {
-		inputFilename, expectedFilename := input, expected
-
-		t.Run(inputFilename, func(t *testing.T) {
+		t.Run(input, func(t *testing.T) {
 			t.Parallel()
 
-			files, err := loadYAMLFiles(fsys, []string{inputFilename})
+			files, err := loadYAMLFiles(fsys, []string{input})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			got, err := files[0].marshalYAML()
+			got, err := files[input].marshalYAML()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if expectedFilename == "" {
-				expectedFilename = inputFilename
+			if expected == "" {
+				expected = input
 			}
-			want, err := fsys.(fs.ReadFileFS).ReadFile(expectedFilename)
+			want, err := fsys.(fs.ReadFileFS).ReadFile(expected)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -115,8 +113,6 @@ func Test_computeNewlineTargets_simple(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -199,8 +195,6 @@ test-code-job1:
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -215,7 +209,7 @@ test-code-job1:
 				t.Fatal(err)
 			}
 
-			f := r[0]
+			f := r["file.yml"]
 			if diff := cmp.Diff(f.newlines, tc.want); diff != "" {
 				t.Errorf("unexpected newlines diff (+got, -want):\n%s", diff)
 			}

--- a/command/pin.go
+++ b/command/pin.go
@@ -5,10 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/sethvargo/ratchet/internal/atomic"
 	"github.com/sethvargo/ratchet/internal/concurrency"
 	"github.com/sethvargo/ratchet/parser"
 	"github.com/sethvargo/ratchet/resolver"
@@ -78,38 +76,21 @@ func (c *PinCommand) Run(ctx context.Context, originalArgs []string) error {
 		return fmt.Errorf("failed to create resolver: %w", err)
 	}
 
-	fsys := os.DirFS(".")
-
-	files, err := loadYAMLFiles(fsys, args)
+	loadResult, err := loadYAMLFiles(os.DirFS("."), args)
 	if err != nil {
 		return err
 	}
 
-	if len(files) > 1 && c.flagOut != "" && !strings.HasSuffix(c.flagOut, "/") {
+	if len(loadResult) > 1 && c.flagOut != "" && !strings.HasSuffix(c.flagOut, "/") {
 		return fmt.Errorf("-out must be a directory when pinning multiple files")
 	}
 
-	if err := parser.Pin(ctx, res, par, files.nodes(), c.flagConcurrency); err != nil {
+	if err := parser.Pin(ctx, res, par, loadResult.nodes(), c.flagConcurrency); err != nil {
 		return fmt.Errorf("failed to pin refs: %w", err)
 	}
 
-	for _, f := range files {
-		outFile := c.flagOut
-		if strings.HasSuffix(c.flagOut, "/") {
-			outFile = filepath.Join(c.flagOut, f.path)
-		}
-		if outFile == "" {
-			outFile = f.path
-		}
-
-		final, err := f.marshalYAML()
-		if err != nil {
-			return fmt.Errorf("failed to marshal yaml for %s: %w", f.path, err)
-		}
-
-		if err := atomic.Write(f.path, outFile, strings.NewReader(final)); err != nil {
-			return fmt.Errorf("failed to save file %s: %w", outFile, err)
-		}
+	if err := loadResult.writeYAMLFiles(c.flagOut); err != nil {
+		return fmt.Errorf("failed to save files: %w", err)
 	}
 
 	return nil

--- a/command/update.go
+++ b/command/update.go
@@ -5,10 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/sethvargo/ratchet/internal/atomic"
 	"github.com/sethvargo/ratchet/parser"
 	"github.com/sethvargo/ratchet/resolver"
 )
@@ -67,42 +65,25 @@ func (c *UpdateCommand) Run(ctx context.Context, originalArgs []string) error {
 		return fmt.Errorf("failed to create resolver: %w", err)
 	}
 
-	fsys := os.DirFS(".")
-
-	files, err := loadYAMLFiles(fsys, args)
+	loadResult, err := loadYAMLFiles(os.DirFS("."), args)
 	if err != nil {
 		return err
 	}
 
-	if len(files) > 1 && c.flagOut != "" && !strings.HasSuffix(c.flagOut, "/") {
+	if len(loadResult) > 1 && c.flagOut != "" && !strings.HasSuffix(c.flagOut, "/") {
 		return fmt.Errorf("-out must be a directory when pinning multiple files")
 	}
 
-	if err := parser.Unpin(ctx, files.nodes()); err != nil {
+	if err := parser.Unpin(ctx, loadResult.nodes()); err != nil {
 		return fmt.Errorf("failed to pin refs: %w", err)
 	}
 
-	if err := parser.Pin(ctx, res, par, files.nodes(), c.flagConcurrency); err != nil {
+	if err := parser.Pin(ctx, res, par, loadResult.nodes(), c.flagConcurrency); err != nil {
 		return fmt.Errorf("failed to pin refs: %w", err)
 	}
 
-	for _, f := range files {
-		outFile := c.flagOut
-		if strings.HasSuffix(c.flagOut, "/") {
-			outFile = filepath.Join(c.flagOut, f.path)
-		}
-		if outFile == "" {
-			outFile = f.path
-		}
-
-		final, err := f.marshalYAML()
-		if err != nil {
-			return fmt.Errorf("failed to marshal yaml for %s: %w", f.path, err)
-		}
-
-		if err := atomic.Write(f.path, outFile, strings.NewReader(final)); err != nil {
-			return fmt.Errorf("failed to save file %s: %w", outFile, err)
-		}
+	if err := loadResult.writeYAMLFiles(c.flagOut); err != nil {
+		return fmt.Errorf("failed to save files: %w", err)
 	}
 
 	return nil

--- a/command/upgrade.go
+++ b/command/upgrade.go
@@ -5,10 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/sethvargo/ratchet/internal/atomic"
 	"github.com/sethvargo/ratchet/internal/concurrency"
 	"github.com/sethvargo/ratchet/parser"
 	"github.com/sethvargo/ratchet/resolver"
@@ -77,48 +75,31 @@ func (c *UpgradeCommand) Run(ctx context.Context, originalArgs []string) error {
 		return fmt.Errorf("failed to create resolver: %w", err)
 	}
 
-	fsys := os.DirFS(".")
-
-	files, err := loadYAMLFiles(fsys, args)
+	loadResult, err := loadYAMLFiles(os.DirFS("."), args)
 	if err != nil {
 		return err
 	}
 
-	if len(files) > 1 && c.flagOut != "" && !strings.HasSuffix(c.flagOut, "/") {
+	if len(loadResult) > 1 && c.flagOut != "" && !strings.HasSuffix(c.flagOut, "/") {
 		return fmt.Errorf("-out must be a directory when upgrading multiple files")
 	}
 
-	if err := parser.Unpin(ctx, files.nodes()); err != nil {
+	if err := parser.Unpin(ctx, loadResult.nodes()); err != nil {
 		return fmt.Errorf("failed to unpin refs: %w", err)
 	}
 
-	if err := parser.Upgrade(ctx, res, par, files.nodes(), c.flagConcurrency); err != nil {
+	if err := parser.Upgrade(ctx, res, par, loadResult.nodes(), c.flagConcurrency); err != nil {
 		return fmt.Errorf("failed to upgrade refs: %w", err)
 	}
 
 	if c.flagPin {
-		if err := parser.Pin(ctx, res, par, files.nodes(), c.flagConcurrency); err != nil {
+		if err := parser.Pin(ctx, res, par, loadResult.nodes(), c.flagConcurrency); err != nil {
 			return fmt.Errorf("failed to pin upgraded refs: %w", err)
 		}
 	}
 
-	for _, f := range files {
-		outFile := c.flagOut
-		if strings.HasSuffix(c.flagOut, "/") {
-			outFile = filepath.Join(c.flagOut, f.path)
-		}
-		if outFile == "" {
-			outFile = f.path
-		}
-
-		final, err := f.marshalYAML()
-		if err != nil {
-			return fmt.Errorf("failed to marshal yaml for %s: %w", f.path, err)
-		}
-
-		if err := atomic.Write(f.path, outFile, strings.NewReader(final)); err != nil {
-			return fmt.Errorf("failed to save file %s: %w", outFile, err)
-		}
+	if err := loadResult.writeYAMLFiles(c.flagOut); err != nil {
+		return fmt.Errorf("failed to save files: %w", err)
 	}
 
 	return nil

--- a/parser/actions.go
+++ b/parser/actions.go
@@ -23,12 +23,12 @@ func (a *Actions) DenormalizeRef(ref string) string {
 }
 
 // Parse pulls the GitHub Actions refs from the documents.
-func (a *Actions) Parse(nodes []*yaml.Node) (*RefsList, error) {
+func (a *Actions) Parse(nodes map[string]*yaml.Node) (*RefsList, error) {
 	var refs RefsList
 
-	for i, node := range nodes {
+	for pth, node := range nodes {
 		if err := a.parseOne(&refs, node); err != nil {
-			return nil, fmt.Errorf("failed to parse node %d: %w", i, err)
+			return nil, fmt.Errorf("failed to parse %s: %w", pth, err)
 		}
 	}
 

--- a/parser/actions_test.go
+++ b/parser/actions_test.go
@@ -107,14 +107,14 @@ jobs:
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			m := helperStringToYAML(t, tc.in)
+			nodes := map[string]*yaml.Node{
+				"test.yml": helperStringToYAML(t, tc.in),
+			}
 
-			refs, err := new(Actions).Parse([]*yaml.Node{m})
+			refs, err := new(Actions).Parse(nodes)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/parser/circleci.go
+++ b/parser/circleci.go
@@ -19,12 +19,12 @@ func (c *CircleCI) DenormalizeRef(ref string) string {
 // Parse pulls the CircleCI refs from the documents. Unfortunately it does not
 // process "orbs" because there is no documented API for resolving orbs to an
 // absolute version.
-func (c *CircleCI) Parse(nodes []*yaml.Node) (*RefsList, error) {
+func (c *CircleCI) Parse(nodes map[string]*yaml.Node) (*RefsList, error) {
 	var refs RefsList
 
-	for i, node := range nodes {
+	for pth, node := range nodes {
 		if err := c.parseOne(&refs, node); err != nil {
-			return nil, fmt.Errorf("failed to parse node %d: %w", i, err)
+			return nil, fmt.Errorf("failed to parse %s: %w", pth, err)
 		}
 	}
 

--- a/parser/circleci_test.go
+++ b/parser/circleci_test.go
@@ -51,14 +51,14 @@ jobs:
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			m := helperStringToYAML(t, tc.in)
+			nodes := map[string]*yaml.Node{
+				"test.yml": helperStringToYAML(t, tc.in),
+			}
 
-			refs, err := new(CircleCI).Parse([]*yaml.Node{m})
+			refs, err := new(CircleCI).Parse(nodes)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/parser/cloudbuild.go
+++ b/parser/cloudbuild.go
@@ -17,12 +17,12 @@ func (c *CloudBuild) DenormalizeRef(ref string) string {
 }
 
 // Parse pulls the Google Cloud Build refs from the documents.
-func (c *CloudBuild) Parse(nodes []*yaml.Node) (*RefsList, error) {
+func (c *CloudBuild) Parse(nodes map[string]*yaml.Node) (*RefsList, error) {
 	var refs RefsList
 
-	for i, node := range nodes {
+	for pth, node := range nodes {
 		if err := c.parseOne(&refs, node); err != nil {
-			return nil, fmt.Errorf("failed to parse node %d: %w", i, err)
+			return nil, fmt.Errorf("failed to parse %s: %w", pth, err)
 		}
 	}
 

--- a/parser/cloudbuild_test.go
+++ b/parser/cloudbuild_test.go
@@ -37,14 +37,14 @@ steps:
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			m := helperStringToYAML(t, tc.in)
+			nodes := map[string]*yaml.Node{
+				"test.yml": helperStringToYAML(t, tc.in),
+			}
 
-			refs, err := new(CloudBuild).Parse([]*yaml.Node{m})
+			refs, err := new(CloudBuild).Parse(nodes)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/parser/drone.go
+++ b/parser/drone.go
@@ -17,12 +17,12 @@ func (d *Drone) DenormalizeRef(ref string) string {
 }
 
 // Parse pulls the Drone Ci refs from the documents.
-func (d *Drone) Parse(nodes []*yaml.Node) (*RefsList, error) {
+func (d *Drone) Parse(nodes map[string]*yaml.Node) (*RefsList, error) {
 	var refs RefsList
 
-	for i, node := range nodes {
+	for pth, node := range nodes {
 		if err := d.parseOne(&refs, node); err != nil {
-			return nil, fmt.Errorf("failed to parse node %d: %w", i, err)
+			return nil, fmt.Errorf("failed to parse %s: %w", pth, err)
 		}
 	}
 

--- a/parser/drone_test.go
+++ b/parser/drone_test.go
@@ -40,14 +40,14 @@ steps:
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			m := helperStringToYAML(t, tc.in)
+			nodes := map[string]*yaml.Node{
+				"test.yml": helperStringToYAML(t, tc.in),
+			}
 
-			refs, err := new(Drone).Parse([]*yaml.Node{m})
+			refs, err := new(Drone).Parse(nodes)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/parser/gitlabci.go
+++ b/parser/gitlabci.go
@@ -18,12 +18,12 @@ func (c *GitLabCI) DenormalizeRef(ref string) string {
 
 // Parse pulls the image references from GitLab CI configuration files. It does
 // not support references with variables.
-func (c *GitLabCI) Parse(nodes []*yaml.Node) (*RefsList, error) {
+func (c *GitLabCI) Parse(nodes map[string]*yaml.Node) (*RefsList, error) {
 	var refs RefsList
 
-	for i, node := range nodes {
+	for pth, node := range nodes {
 		if err := c.parseOne(&refs, node); err != nil {
-			return nil, fmt.Errorf("failed to parse node %d: %w", i, err)
+			return nil, fmt.Errorf("failed to parse %s: %w", pth, err)
 		}
 	}
 

--- a/parser/gitlabci_test.go
+++ b/parser/gitlabci_test.go
@@ -139,14 +139,14 @@ job2:
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			m := helperStringToYAML(t, tc.in)
+			nodes := map[string]*yaml.Node{
+				"test.yml": helperStringToYAML(t, tc.in),
+			}
 
-			refs, err := new(GitLabCI).Parse([]*yaml.Node{m})
+			refs, err := new(GitLabCI).Parse(nodes)
 			if err != nil {
 				fmt.Println(refs)
 				t.Fatal(err)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -61,14 +61,14 @@ jobs:
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			m := helperStringToYAML(t, tc.in)
+			nodes := map[string]*yaml.Node{
+				"test.yml": helperStringToYAML(t, tc.in),
+			}
 
-			if err := Check(ctx, par, []*yaml.Node{m}); err != nil {
+			if err := Check(ctx, par, nodes); err != nil {
 				if tc.err == "" {
 					t.Fatal(err)
 				} else {
@@ -209,14 +209,16 @@ jobs:
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			m := helperStringToYAML(t, tc.in)
 
-			if err := Pin(ctx, res, par, []*yaml.Node{m}, 2); err != nil {
+			nodes := map[string]*yaml.Node{
+				"test.yml": m,
+			}
+
+			if err := Pin(ctx, res, par, nodes, 2); err != nil {
 				if tc.err == "" {
 					t.Fatal(err)
 				} else {
@@ -372,14 +374,16 @@ jobs:
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			m := helperStringToYAML(t, tc.in)
 
-			if err := Upgrade(ctx, res, par, []*yaml.Node{m}, 2); err != nil {
+			nodes := map[string]*yaml.Node{
+				"test.yml": m,
+			}
+
+			if err := Upgrade(ctx, res, par, nodes, 2); err != nil {
 				if tc.err == "" {
 					t.Fatal(err)
 				} else {
@@ -446,14 +450,16 @@ func TestUnpin(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			m := helperStringToYAML(t, tc.in)
 
-			if err := Unpin(ctx, []*yaml.Node{m}); err != nil {
+			nodes := map[string]*yaml.Node{
+				"test.yml": m,
+			}
+
+			if err := Unpin(ctx, nodes); err != nil {
 				t.Fatal(err)
 			}
 
@@ -500,8 +506,6 @@ func TestAppendOriginalToComment(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -567,8 +571,6 @@ func TestExtractOriginalFromComment(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/parser/refs_test.go
+++ b/parser/refs_test.go
@@ -44,8 +44,6 @@ func Test_IsAbsolute(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.val, func(t *testing.T) {
 			t.Parallel()
 

--- a/parser/tekton.go
+++ b/parser/tekton.go
@@ -17,11 +17,11 @@ func (t *Tekton) DenormalizeRef(ref string) string {
 }
 
 // Parse pulls the Tekton Ci refs from the documents.
-func (t *Tekton) Parse(nodes []*yaml.Node) (*RefsList, error) {
+func (t *Tekton) Parse(nodes map[string]*yaml.Node) (*RefsList, error) {
 	var refs RefsList
-	for i, node := range nodes {
+	for pth, node := range nodes {
 		if err := t.parseOne(&refs, node); err != nil {
-			return nil, fmt.Errorf("failed to parse node %d: %w", i, err)
+			return nil, fmt.Errorf("failed to parse %s: %w", pth, err)
 		}
 	}
 

--- a/parser/tekton_test.go
+++ b/parser/tekton_test.go
@@ -44,14 +44,14 @@ spec:
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			m := helperStringToYAML(t, tc.in)
+			nodes := map[string]*yaml.Node{
+				"test.yml": helperStringToYAML(t, tc.in),
+			}
 
-			refs, err := new(Tekton).Parse([]*yaml.Node{m})
+			refs, err := new(Tekton).Parse(nodes)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/resolver/actions_test.go
+++ b/resolver/actions_test.go
@@ -35,8 +35,6 @@ func TestActions_Resolve(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -104,8 +102,6 @@ func TestActions_LatestVersion(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -172,8 +168,6 @@ func TestParseActionRef(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/resolver/container_test.go
+++ b/resolver/container_test.go
@@ -33,8 +33,6 @@ func TestContainer_Resolve(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
This also centralizes the YAML writing into a single place (reducing boilerplate in commands) and cleans up some unnecessary variable duplication in tests.