### PR TITLE
Add support for Windows paths

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -152,6 +152,9 @@ func loadYAMLFiles(fsys fs.FS, paths []string) (loadResults, error) {
 	r := make(loadResults, len(paths))
 
 	for _, pth := range paths {
+		// Normalize the file path to ensure consistent behavior across different
+		// operating systems. filepath.Clean removes redundant elements, and
+		// filepath.ToSlash converts Windows-style backslashes to slashes.
 		pth = filepath.ToSlash(filepath.Clean(pth))
 		contents, err := fs.ReadFile(fsys, pth)
 		if err != nil {

--- a/command/command.go
+++ b/command/command.go
@@ -152,7 +152,7 @@ func loadYAMLFiles(fsys fs.FS, paths []string) (loadResults, error) {
 	r := make(loadResults, len(paths))
 
 	for _, pth := range paths {
-		pth = strings.TrimPrefix(pth, "./")
+		pth = filepath.ToSlash(filepath.Clean(pth))
 		contents, err := fs.ReadFile(fsys, pth)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read file %s: %w", pth, err)


### PR DESCRIPTION
Add support for Windows paths (paths with backwards slashes as path
separators).

This makes it easier to use Ratchet on Windows machines.
