### PR TITLE
feat: basic pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+---
+- id: ratchet-lint
+  name: Check GitHub Actions for unpinned versions
+  description: Runs ratchet to lint GitHub Actions workflow files
+  language: golang
+  types: ["yaml"]
+  files: ^\.github/workflows/
+  entry: ratchet lint

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,3 +6,10 @@
   types: ["yaml"]
   files: ^\.github/workflows/
   entry: ratchet lint
+- id: ratchet-pin
+  name: Pin GitHub Actions versions
+  description: Runs ratchet to pin GitHub Actions workflow files
+  language: golang
+  types: ["yaml"]
+  files: ^\.github/workflows/
+  entry: ratchet pin

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,3 +13,24 @@
   types: ["yaml"]
   files: ^\.github/workflows/
   entry: ratchet pin
+- id: ratchet-pin
+  name: Unpin GitHub Actions versions
+  description: Runs ratchet to unpin GitHub Actions workflow files
+  language: golang
+  types: ["yaml"]
+  files: ^\.github/workflows/
+  entry: ratchet unpin
+- id: ratchet-update
+  name: Update GitHub Actions versions
+  description: Runs ratchet to update GitHub Actions workflow files
+  language: golang
+  types: ["yaml"]
+  files: ^\.github/workflows/
+  entry: ratchet update
+- id: ratchet-upgrade
+  name: Upgrade GitHub Actions versions
+  description: Runs ratchet to upgrade GitHub Actions workflow files
+  language: golang
+  types: ["yaml"]
+  files: ^\.github/workflows/
+  entry: ratchet upgrade

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ repos:
   - repo: https://github.com/sethvargo/ratchet
     rev: v0.11.4
     hooks:
-      - id: ratchet-lint
+      - id: ratchet-pin
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,19 @@ function ratchet {
 }
 ```
 
+#### Pre-commit
+
+Ratchet can be ran as a pre-commit hook.
+In your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/sethvargo/ratchet
+    rev: v0.11.4
+    hooks:
+      - id: ratchet-lint
+```
+
 
 ## Auth
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ In your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/sethvargo/ratchet
-    rev: v0.11.4
+    rev: main
     hooks:
       - id: ratchet-pin
 ```


### PR DESCRIPTION
This allows users to share ratchet locally with other maintainers + a simple way to introduce in CI w/ standardized caching, test selection, etc.

I tested this locally using a rev from my branch,

<img width="2880" height="1920" alt="20251210_19h18m15s_grim" src="https://github.com/user-attachments/assets/760d54aa-d5a2-4554-b0c2-7f58732a5aaf" />

Checked:
- Passes at HEAD
- Fails if an action is unpinned
- Is skipped if non-workflow file is changed