### PR TITLE
Ratchet pin pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: "ratchet-pin"
+  name: "Ratchet: Pin GitHub Action versions"
+  entry: ratchet
+  args: ["pin"]
+  language: golang
+  files: ^\.github/workflows/.*\.(yml|yaml)$
+  pass_filenames: true
+  language_version: 1.24.2


### PR DESCRIPTION
Add basic config to allow using Ratchet as a pre-commit hook, ensuring everything is always pinned.

I created https://github.com/tmr232/ratchet-pre-commit and then realized that it'll be easier to do (and easier to trust) as part of the project itself. 

If you're interested in merging this, I'll be happy to add relevant docs/touchups as required.

I pushed a tag to my fork so that it can be easily tested, so adding the following to a `.pre-commit-config.yaml` should do the trick:

```yaml
repos:
- repo: https://github.com/tmr232/ratchet
  rev: v0.11.44
  hooks:
    - id: ratchet-pin
```

And thanks again for creating this awesome project!