### PR TITLE
fix: correct bounds out of range error

### DIFF
--- a/resolver/actions.go
+++ b/resolver/actions.go
@@ -110,7 +110,10 @@ func (g *Actions) LatestVersion(ctx context.Context, value string) (string, erro
 	version := *release.TagName
 	if strings.HasPrefix(ref, "v") {
 		refPrecision := strings.Count(githubRef.ref, ".")
-		versionParts := strings.Split(*release.TagName, ".")
+		for strings.Count(version, ".") < refPrecision {
+			version += ".0"
+		}
+		versionParts := strings.Split(version, ".")
 		version = strings.Join(versionParts[:refPrecision+1], ".")
 	}
 

--- a/resolver/actions_test.go
+++ b/resolver/actions_test.go
@@ -90,6 +90,16 @@ func TestActions_LatestVersion(t *testing.T) {
 			exp:  `github/codeql-action/init@codeql-bundle-v[0-9]+\.[0-9]+\.[0-9]+`,
 		},
 		{
+			name: "floating-tag-with-patch-precision",
+			in:   "google-github-actions/auth@v3.0.0",
+			exp:  `google-github-actions/auth@v[0-9]+\.[0-9]+\.[0-9]+`,
+		},
+		{
+			name: "floating-tag-with-minor-precision",
+			in:   "actions/github-script@v8.0",
+			exp:  `actions/github-script@v[0-9]+\.[0-9]+`,
+		},
+		{
 			name: "skips-default-branch",
 			in:   "github/codeql-action/init@main",
 			exp:  `github/codeql-action/init@main`,


### PR DESCRIPTION
The Actions.LatestVersion function previously assumed that release.TagName and githubRef.ref had the same precision. This was not always true.

In some cases the release is on a floating tag like `v3` and the GitHub ref comes back as `v3.0.0` - in this case the LatestVersion function panics with a slice bounds out of range error. This is corrected by checking the precision of the release tag against the GitHub ref prior to manipulation.

Test file:
```yaml
name: Test Thing
on:
  workflow_dispatch:
jobs:
  test:
    runs-on: ubuntu-latest
    permissions:
      contents: read
      id-token: write
    steps:
      - name: Checkout repository
        uses: actions/checkout@v6.0.2
      - name: Authenticate with Google Cloud
        uses: google-github-actions/auth@v3.0.0
        with:
          project_id: 'test'
          workload_identity_provider: "projects/12345/locations/global/workloadIdentityPools/my-pool/providers/github-actions"
          service_account: "test@test.iam.gserviceaccount.com"
```

Current behavior:
```
$ ratchet upgrade test.yaml
panic: runtime error: slice bounds out of range [:3] with capacity 1

goroutine 6 [running]:
github.com/sethvargo/ratchet/resolver.(*Actions).LatestVersion(0x140000581e8, {0x1053dd378, 0x14000107440}, {0x140000186fa, 0x21})
        github.com/sethvargo/ratchet/resolver/actions.go:114 +0x3d8
github.com/sethvargo/ratchet/resolver.(*DefaultResolver).LatestVersion(0x140000266d0, {0x1053dd378, 0x14000107440}, {0x140000186f0, 0x2b})
        github.com/sethvargo/ratchet/resolver/resolver.go:67 +0xe0
github.com/sethvargo/ratchet/parser.Upgrade.func1()
        github.com/sethvargo/ratchet/parser/parser.go:239 +0x200
created by github.com/sethvargo/ratchet/parser.Upgrade in goroutine 1
        github.com/sethvargo/ratchet/parser/parser.go:217 +0x11c
```

New behavior:
```
$ go run main.go upgrade test.yaml
$ cat test.yaml 
name: Test Thing
on:
  workflow_dispatch:
jobs:
  test:
    runs-on: ubuntu-latest
    permissions:
      contents: read
      id-token: write
    steps:
      - name: Checkout repository
        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
      - name: Authenticate with Google Cloud
        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3.0.0
        with:
          project_id: 'test'
          workload_identity_provider: "projects/12345/locations/global/workloadIdentityPools/my-pool/providers/github-actions"
          service_account: "test@test.iam.gserviceaccount.com"
```

All existing test cases still pass without modification.