### PR TITLE
feat: support parallel step blocks in GitHub Actions workflows

### DIFF
--- a/parser/actions.go
+++ b/parser/actions.go
@@ -35,6 +35,40 @@ func (a *Actions) Parse(nodes map[string]*yaml.Node) (*RefsList, error) {
 	return &refs, nil
 }
 
+func (a *Actions) processStep(refs *RefsList, step *yaml.Node) {
+	if step.Kind != yaml.MappingNode {
+		return
+	}
+
+	for k, property := range step.Content {
+		if property.Value == "uses" {
+			uses := step.Content[k+1]
+
+			if strings.Contains(uses.Value, "${{") {
+				continue
+			}
+
+			switch {
+			case strings.HasPrefix(uses.Value, "docker://"):
+				ref := resolver.NormalizeContainerRef(uses.Value)
+				refs.Add(ref, uses)
+			case strings.Contains(uses.Value, "@"):
+				ref := resolver.NormalizeActionsRef(uses.Value)
+				refs.Add(ref, uses)
+			}
+		}
+
+		if property.Value == "parallel" && len(step.Content) > k+1 {
+			parallelSteps := step.Content[k+1]
+			if parallelSteps.Kind == yaml.SequenceNode {
+				for _, innerStep := range parallelSteps.Content {
+					a.processStep(refs, innerStep)
+				}
+			}
+		}
+	}
+}
+
 func (a *Actions) parseOne(refs *RefsList, node *yaml.Node) error {
 	if node == nil {
 		return nil
@@ -75,31 +109,7 @@ func (a *Actions) parseOne(refs *RefsList, node *yaml.Node) error {
 					if runMap.Value == "steps" {
 						steps := runs.Content[j+1]
 						for _, step := range steps.Content {
-							if step.Kind != yaml.MappingNode {
-								continue
-							}
-
-							for k, property := range step.Content {
-								if property.Value == "uses" {
-									uses := step.Content[k+1]
-									// Ignore interpolations, since we cannot resolve most of
-									// their values.
-									if strings.Contains(uses.Value, "${{") {
-										continue
-									}
-
-									// Only include references to remote workflows. This could be
-									// a local workflow, which should not be pinned.
-									switch {
-									case strings.HasPrefix(uses.Value, "docker://"):
-										ref := resolver.NormalizeContainerRef(uses.Value)
-										refs.Add(ref, uses)
-									case strings.Contains(uses.Value, "@"):
-										ref := resolver.NormalizeActionsRef(uses.Value)
-										refs.Add(ref, uses)
-									}
-								}
-							}
+							a.processStep(refs, step)
 						}
 					}
 				}
@@ -170,32 +180,7 @@ func (a *Actions) parseOne(refs *RefsList, node *yaml.Node) error {
 						if sub.Value == "steps" {
 							steps := jobMap.Content[j+1]
 							for _, step := range steps.Content {
-								if step.Kind != yaml.MappingNode {
-									continue
-								}
-
-								for k, property := range step.Content {
-									if property.Value == "uses" {
-										uses := step.Content[k+1]
-
-										// Ignore interpolations, since we cannot resolve most of
-										// their values.
-										if strings.Contains(uses.Value, "${{") {
-											continue
-										}
-
-										// Only include references to remote workflows. This could be
-										// a local workflow, which should not be pinned.
-										switch {
-										case strings.HasPrefix(uses.Value, "docker://"):
-											ref := resolver.NormalizeContainerRef(uses.Value)
-											refs.Add(ref, uses)
-										case strings.Contains(uses.Value, "@"):
-											ref := resolver.NormalizeActionsRef(uses.Value)
-											refs.Add(ref, uses)
-										}
-									}
-								}
+								a.processStep(refs, step)
 							}
 						}
 

--- a/parser/actions_test.go
+++ b/parser/actions_test.go
@@ -92,6 +92,86 @@ runs:
 			},
 		},
 		{
+			name: "parallel_steps",
+			in: `
+jobs:
+  my_job:
+    steps:
+      - uses: 'actions/checkout@v3'
+      - parallel:
+          - name: Set up Docker Buildx
+            uses: 'docker/setup-buildx-action@v4'
+          - name: Login to Registry
+            uses: 'docker/login-action@v3'
+      - uses: 'actions/upload-artifact@v4'
+`,
+			exp: []string{
+				"actions://actions/checkout@v3",
+				"actions://actions/upload-artifact@v4",
+				"actions://docker/login-action@v3",
+				"actions://docker/setup-buildx-action@v4",
+			},
+		},
+		{
+			name: "parallel_steps_composite",
+			in: `
+runs:
+  using: 'composite'
+  steps:
+    - uses: 'actions/checkout@v3'
+    - parallel:
+        - uses: 'actions/setup-node@v4'
+        - uses: 'actions/setup-python@v5'
+`,
+			exp: []string{
+				"actions://actions/checkout@v3",
+				"actions://actions/setup-node@v4",
+				"actions://actions/setup-python@v5",
+			},
+		},
+		{
+			name: "parallel_mixed",
+			in: `
+jobs:
+  my_job:
+    steps:
+      - parallel:
+          - uses: 'actions/checkout@v3'
+          - uses: 'docker://ubuntu:20.04'
+      - uses: 'actions/upload-artifact@v4'
+      - parallel:
+          - uses: 'actions/cache@v4'
+`,
+			exp: []string{
+				"actions://actions/cache@v4",
+				"actions://actions/checkout@v3",
+				"actions://actions/upload-artifact@v4",
+				"container://ubuntu:20.04",
+			},
+		},
+		{
+			name: "parallel_with_background_and_wait",
+			in: `
+jobs:
+  my_job:
+    steps:
+      - name: Start service
+        uses: 'docker://redis:7'
+        background: true
+      - parallel:
+          - uses: 'actions/checkout@v3'
+          - uses: 'actions/setup-node@v4'
+      - wait-all
+      - uses: 'actions/upload-artifact@v4'
+`,
+			exp: []string{
+				"actions://actions/checkout@v3",
+				"actions://actions/setup-node@v4",
+				"actions://actions/upload-artifact@v4",
+				"container://redis:7",
+			},
+		},
+		{
 			name: "ignores_interpolated",
 			in: `
 jobs:


### PR DESCRIPTION
## Summary
GitHub Actions added [`parallel` step blocks](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/) (announced 2026-06-25). Ratchet's parser currently misses `uses:` refs inside `parallel:` blocks because it only inspects direct step MappingNodes so when a step is `- parallel:`, the value is a SequenceNode of inner steps that gets skipped.

This causes ratchet to either:
- Miss pinning actions inside parallel blocks during `pin`/`upgrade`
- Strip existing SHA pins during `upgrade` (reverting to bare tags)

## Changes
- **Extract `processStep` helper** and deduplicate the step-processing logic that was repeated for composite actions (`runs.steps`) and job steps (`jobs.*.steps`)
- **Add `parallel:` recursion** so when `processStep` encounters a `parallel:` key, it recurses into the inner SequenceNode and processes each nested step
- **Add 4 test cases** for the parallel in jobs, parallel in composite actions, mixed parallel/sequential, and parallel with `background`/`wait-all`

Note: Parallel is not technically allowed for composite actions but kept that test in just in case 

## Before/After

**Stock ratchet** — actions inside `parallel:` left unpinned:
```yaml
steps:
  - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7
  - parallel:
      - uses: docker/setup-buildx-action@v4        # ← missed
      - uses: docker/login-action@v3                # ← missed
```

**With this fix** — all refs pinned:
```yaml
steps:
  - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7
  - parallel:
      - uses: docker/setup-buildx-action@<sha>  # ratchet:docker/setup-buildx-action@v4
      - uses: docker/login-action@<sha>          # ratchet:docker/login-action@v3
```

## Test plan
- [x] 4 new test cases in `parser/actions_test.go` — all pass
- [x] All existing tests pass (`go test ./parser/ -v`)
- [x] Full test suite passes (`go test ./...` with `GITHUB_TOKEN`)
- [x] Manual test: built local binary and ran `upgrade` against a real workflow with parallel blocks — all refs inside parallel blocks correctly pinned