### PR TITLE
Skip container refs that contain CI variables

### DIFF
--- a/parser/circleci.go
+++ b/parser/circleci.go
@@ -75,8 +75,7 @@ func (c *CircleCI) parseOne(refs *RefsList, node *yaml.Node) error {
 
 							for propKey, propValue := range mapPairs(subMap) {
 								if propKey.Value == "image" {
-									ref := resolver.NormalizeContainerRef(propValue.Value)
-									refs.Add(ref, propValue)
+									addContainerRef(refs, propValue)
 									break
 								}
 							}

--- a/parser/circleci_test.go
+++ b/parser/circleci_test.go
@@ -23,6 +23,16 @@ executors:
 			exp: nil,
 		},
 		{
+			name: "variable_image_reference",
+			in: `
+executors:
+  my-executor:
+    docker:
+      - image: '$CUSTOM_IMAGE:latest'
+`,
+			exp: nil,
+		},
+		{
 			name: "executor",
 			in: `
 executors:

--- a/parser/cloudbuild.go
+++ b/parser/cloudbuild.go
@@ -63,8 +63,7 @@ func (c *CloudBuild) parseOne(refs *RefsList, node *yaml.Node) error {
 
 				for propKey, propValue := range mapPairs(step) {
 					if propKey.Value == "name" {
-						ref := resolver.NormalizeContainerRef(propValue.Value)
-						refs.Add(ref, propValue)
+						addContainerRef(refs, propValue)
 						break
 					}
 				}

--- a/parser/cloudbuild_test.go
+++ b/parser/cloudbuild_test.go
@@ -23,6 +23,14 @@ jobs:
 			exp: nil,
 		},
 		{
+			name: "variable_image_reference",
+			in: `
+steps:
+  - name: 'gcr.io/$PROJECT_ID/builder'
+`,
+			exp: nil,
+		},
+		{
 			name: "steps",
 			in: `
 steps:

--- a/parser/drone.go
+++ b/parser/drone.go
@@ -61,8 +61,7 @@ func (d *Drone) parseOne(refs *RefsList, node *yaml.Node) error {
 
 				for propKey, propValue := range mapPairs(step) {
 					if propKey.Value == "image" {
-						ref := resolver.NormalizeContainerRef(propValue.Value)
-						refs.Add(ref, propValue)
+						addContainerRef(refs, propValue)
 						break
 					}
 				}

--- a/parser/drone_test.go
+++ b/parser/drone_test.go
@@ -23,6 +23,15 @@ jobs:
 			exp: nil,
 		},
 		{
+			name: "variable_image_reference",
+			in: `
+steps:
+  - name: build
+    image: $PLUGIN_IMAGE
+`,
+			exp: nil,
+		},
+		{
 			name: "steps",
 			in: `
 steps:

--- a/parser/gitlabci.go
+++ b/parser/gitlabci.go
@@ -83,8 +83,7 @@ func (c *GitLabCI) parseOne(refs *RefsList, m *yaml.Node) error {
 						imageRef = image
 					}
 
-					ref := resolver.NormalizeContainerRef(imageRef.Value)
-					refs.Add(ref, imageRef)
+					addContainerRef(refs, imageRef)
 				} else if propKey.Value == "services" {
 					for _, service := range propValue.Content {
 						if service.Kind == yaml.MappingNode {
@@ -97,8 +96,7 @@ func (c *GitLabCI) parseOne(refs *RefsList, m *yaml.Node) error {
 						} else {
 							imageRef = service
 						}
-						ref := resolver.NormalizeContainerRef(imageRef.Value)
-						refs.Add(ref, imageRef)
+						addContainerRef(refs, imageRef)
 					}
 				}
 			}

--- a/parser/gitlabci_test.go
+++ b/parser/gitlabci_test.go
@@ -34,7 +34,7 @@ variables:
 			exp: nil,
 		},
 		{
-			name: "wrong_image_reference",
+			name: "variable_image_reference",
 			in: `
 test_job:
   stage: lint
@@ -42,8 +42,39 @@ test_job:
     SCAN_DIR: .
   image: $CI_REGISTRY/image:tag
 `,
+			exp: nil,
+		},
+		{
+			name: "bare_variable_image_reference",
+			in: `
+test_job:
+  stage: test
+  image: $GOTESTFMT_IMAGE_LATEST
+`,
+			exp: nil,
+		},
+		{
+			name: "braced_variable_image_reference",
+			in: `
+test_job:
+  stage: test
+  image: ${CI_REGISTRY_IMAGE}:latest
+`,
+			exp: nil,
+		},
+		{
+			name: "variable_service_reference",
+			in: `
+job:
+  image: node:12
+  services:
+    - postgres:14.3
+    - name: $CI_REGISTRY_IMAGE/db:latest
+      alias: db
+`,
 			exp: []string{
-				"container://$CI_REGISTRY/image:tag",
+				"container://node:12",
+				"container://postgres:14.3",
 			},
 		},
 		{

--- a/parser/refs.go
+++ b/parser/refs.go
@@ -10,6 +10,7 @@ import (
 	// Using banydonk/yaml instead of the default yaml pkg because the default
 	// pkg incorrectly escapes unicode. https://github.com/go-yaml/yaml/issues/737
 	"github.com/braydonk/yaml"
+	"github.com/sethvargo/ratchet/resolver"
 )
 
 type RefsList struct {
@@ -51,6 +52,18 @@ func mapPairs(node *yaml.Node) iter.Seq2[*yaml.Node, *yaml.Node] {
 			}
 		}
 	}
+}
+
+// addContainerRef normalizes the given node's value as a container reference and
+// records it in refs. It skips values that contain a variable interpolation such
+// as "$VAR" or "${VAR}", because their value is only known at runtime and cannot
+// be resolved to a digest. "$" is never valid in a container reference, so its
+// presence unambiguously signals interpolation.
+func addContainerRef(refs *RefsList, node *yaml.Node) {
+	if node == nil || strings.Contains(node.Value, "$") {
+		return
+	}
+	refs.Add(resolver.NormalizeContainerRef(node.Value), node)
 }
 
 // isAbsolute returns true if the given reference is absolute, or false

--- a/parser/tekton.go
+++ b/parser/tekton.go
@@ -66,8 +66,7 @@ func (d *Tekton) findImages(refs *RefsList, node *yaml.Node) {
 	if node.Kind == yaml.MappingNode {
 		for key, value := range mapPairs(node) {
 			if key.Value == "image" {
-				ref := resolver.NormalizeContainerRef(value.Value)
-				refs.Add(ref, value)
+				addContainerRef(refs, value)
 				return
 			}
 			d.findImages(refs, value)

--- a/parser/tekton_test.go
+++ b/parser/tekton_test.go
@@ -42,6 +42,20 @@ spec:
 			},
 		},
 		{
+			name: "variable_image_reference",
+			in: `
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+   name: testData
+spec:
+    steps:
+      - name: build
+        image: $BUILDER_IMAGE
+`,
+			exp: nil,
+		},
+		{
 			name: "step_field_named_image",
 			in: `
 apiVersion: tekton.dev/v1


### PR DESCRIPTION
## Summary

`ratchet pin -parser gitlabci` (and the other pipeline parsers) crashes when an image reference uses a CI variable, e.g. `image: $CI_REGISTRY_IMAGE:latest` or `image: $GOTESTFMT_IMAGE_LATEST`. Those values are only known at runtime, but the parsers collected them as container refs, so pin handed `container://$GOTESTFMT_IMAGE_LATEST` to the resolver, which rejected it because `$` is never valid in a container reference. The whole run failed:

```
failed to pin refs: failed to resolve "container://$GOTESTFMT_IMAGE_LATEST": failed to parse Container ref: could not parse reference: $GOTESTFMT_IMAGE_LATEST
```

## Fix

Add a shared `addContainerRef` helper in `parser/refs.go` that normalizes a value as a container reference and skips any value containing `$`. `$` never appears in a valid container reference, so its presence unambiguously signals interpolation (`$VAR` or `${VAR}`). The GitLab CI, CircleCI, CloudBuild, Drone, and Tekton parsers all route through it. Dropping variable refs from the list means pin, upgrade, lint, and check all treat them as nothing to do, mirroring the Actions parser's existing `${{` skip.

The Actions parser is left alone: it already guards `${{`, and GitHub doesn't expand bare `$VAR` in image fields.

## Tests

Added parse cases (bare `$VAR`, `${VAR}`, and a variable `services` entry) to the GitLab CI, CircleCI, CloudBuild, Drone, and Tekton suites asserting the variable ref is skipped while sibling literal refs are still collected. Verified each new case fails without the guard and passes with it, and confirmed end to end that `pin` and `lint` now exit 0 on a file matching the report.

Fixes https://github.com/sethvargo/ratchet/issues/134
