### PR TITLE
Add opt-in bake delay for pin, update, and upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,30 @@ ratchet upgrade -out workflow-compiled.yml workflow.yml
 > [!NOTE]
 > Performs an `update` if the constraint ref is for a branch.
 
+#### Bake delay
+
+When running `pin`, `update`, or `upgrade`, the `-bake-delay` flag (or the
+`RATCHET_BAKE_DELAY` environment variable) refuses to resolve any commit,
+release, or image younger than the given duration. This lets a version "bake"
+before you adopt it, lowering the risk of pinning one that was compromised and
+published minutes ago. pnpm calls this `minimumReleaseAge`; Dependabot calls it
+`cooldown`. It is off by default.
+
+```shell
+# only adopt versions at least 24 hours old
+ratchet update -bake-delay 24h workflow.yml
+
+# also configurable via the environment
+RATCHET_BAKE_DELAY=24h ratchet upgrade workflow.yml
+```
+
+For GitHub Actions, ratchet uses the most trustworthy time it can find: a
+release's `published_at` (set by GitHub and not forgeable), then an annotated
+tag's date, then the commit date. Only the release date is tamper-proof, so bake
+delay reduces risk but does not guarantee against a compromised upstream. It
+does not detect a tag repointed at an already-old commit, and a moving major tag
+like `v4` (which has no matching release) falls back to the commit date.
+
 #### Lint
 
 The `lint` command reports if all versions are pinned, printing any violations,

--- a/command/command.go
+++ b/command/command.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	// Using banydonk/yaml instead of the default yaml pkg because the default
 	// pkg incorrectly escapes unicode. https://github.com/go-yaml/yaml/issues/737
@@ -80,6 +81,13 @@ func parseFlags(f *flag.FlagSet, args []string) ([]string, error) {
 	finalArgs = append(finalArgs, f.Args()...)
 
 	return finalArgs, merr
+}
+
+// bakeDelayFromEnv returns the bake delay configured via RATCHET_BAKE_DELAY, or
+// 0 when it is unset or unparseable. It seeds the -bake-delay flag default.
+func bakeDelayFromEnv() time.Duration {
+	d, _ := time.ParseDuration(os.Getenv("RATCHET_BAKE_DELAY"))
+	return d
 }
 
 // extractCommandAndArgs is a helper that pulls the subcommand and arguments.

--- a/command/pin.go
+++ b/command/pin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/sethvargo/ratchet/internal/concurrency"
 	"github.com/sethvargo/ratchet/parser"
@@ -39,6 +40,7 @@ type PinCommand struct {
 	flagConcurrency int64
 	flagParser      string
 	flagOut         string
+	flagBakeDelay   time.Duration
 }
 
 func (c *PinCommand) Desc() string {
@@ -57,6 +59,9 @@ func (c *PinCommand) Flags() *flag.FlagSet {
 	f.StringVar(&c.flagParser, "parser", "actions", "parser to use")
 	f.StringVar(&c.flagOut, "out", "", "output path (defaults to input file)")
 
+	f.DurationVar(&c.flagBakeDelay, "bake-delay", bakeDelayFromEnv(),
+		"minimum age before ratchet resolves a commit, release, or image (0=off); also RATCHET_BAKE_DELAY")
+
 	return f
 }
 
@@ -71,7 +76,7 @@ func (c *PinCommand) Run(ctx context.Context, originalArgs []string) error {
 		return err
 	}
 
-	res, err := resolver.NewDefaultResolver(ctx)
+	res, err := resolver.NewDefaultResolver(ctx, resolver.WithBakeDelay(c.flagBakeDelay))
 	if err != nil {
 		return fmt.Errorf("failed to create resolver: %w", err)
 	}

--- a/command/update.go
+++ b/command/update.go
@@ -60,7 +60,7 @@ func (c *UpdateCommand) Run(ctx context.Context, originalArgs []string) error {
 		return err
 	}
 
-	res, err := resolver.NewDefaultResolver(ctx)
+	res, err := resolver.NewDefaultResolver(ctx, resolver.WithBakeDelay(c.flagBakeDelay))
 	if err != nil {
 		return fmt.Errorf("failed to create resolver: %w", err)
 	}

--- a/command/upgrade.go
+++ b/command/upgrade.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/sethvargo/ratchet/internal/concurrency"
 	"github.com/sethvargo/ratchet/parser"
@@ -37,6 +38,7 @@ type UpgradeCommand struct {
 	flagParser      string
 	flagOut         string
 	flagPin         bool
+	flagBakeDelay   time.Duration
 }
 
 func (c *UpgradeCommand) Desc() string {
@@ -56,6 +58,9 @@ func (c *UpgradeCommand) Flags() *flag.FlagSet {
 	f.StringVar(&c.flagOut, "out", "", "output path (defaults to input file)")
 	f.BoolVar(&c.flagPin, "pin", true, "pin resolved upgraded versions")
 
+	f.DurationVar(&c.flagBakeDelay, "bake-delay", bakeDelayFromEnv(),
+		"minimum age before ratchet resolves a commit, release, or image (0=off); also RATCHET_BAKE_DELAY")
+
 	return f
 }
 
@@ -70,7 +75,7 @@ func (c *UpgradeCommand) Run(ctx context.Context, originalArgs []string) error {
 		return err
 	}
 
-	res, err := resolver.NewDefaultResolver(ctx)
+	res, err := resolver.NewDefaultResolver(ctx, resolver.WithBakeDelay(c.flagBakeDelay))
 	if err != nil {
 		return fmt.Errorf("failed to create resolver: %w", err)
 	}

--- a/resolver/actions.go
+++ b/resolver/actions.go
@@ -82,6 +82,85 @@ func (g *Actions) Resolve(ctx context.Context, value string) (string, error) {
 	return fmt.Sprintf("%s@%s", name, sha), nil
 }
 
+// ResolvedTimestamp reports the most trustworthy known publish or creation time
+// for value, trying sources from most to least trustworthy: a GitHub release's
+// server-set published_at, then an annotated tag's tagger date, then the
+// resolved commit's committer date, then its author date. It returns nil when
+// no time can be determined.
+func (g *Actions) ResolvedTimestamp(ctx context.Context, value string) (*Timestamp, error) {
+	githubRef, err := ParseActionRef(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse github ref: %w", err)
+	}
+	owner := githubRef.owner
+	repo := githubRef.repo
+	ref := githubRef.ref
+
+	// Most trustworthy: a release's published_at is set server-side by GitHub
+	// and cannot be backdated by the upstream repository.
+	release, resp, err := g.client.Repositories.GetReleaseByTag(ctx, owner, repo, ref)
+	if err != nil {
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			return nil, fmt.Errorf("failed to get release for tag %s: %w", ref, err)
+		}
+	} else if release != nil {
+		if published := release.GetPublishedAt(); !published.Time.IsZero() {
+			return newTimestamp(published.Time, "release"), nil
+		}
+		if created := release.GetCreatedAt(); !created.Time.IsZero() {
+			return newTimestamp(created.Time, "release"), nil
+		}
+	}
+
+	// An annotated tag's tagger date is when the tag was created, which catches
+	// an attacker who points a fresh annotated tag at an old commit. Lightweight
+	// tags carry no date and fall through to the commit below.
+	tagRef, resp, err := g.client.Git.GetRef(ctx, owner, repo, "tags/"+ref)
+	if err != nil {
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			return nil, fmt.Errorf("failed to get tag ref %s: %w", ref, err)
+		}
+	} else if obj := tagRef.GetObject(); obj != nil && obj.GetType() == "tag" {
+		tag, _, err := g.client.Git.GetTag(ctx, owner, repo, obj.GetSHA())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get tag object %s: %w", ref, err)
+		}
+		if tagger := tag.GetTagger(); tagger != nil {
+			if date := tagger.GetDate(); !date.Time.IsZero() {
+				return newTimestamp(date.Time, "tag"), nil
+			}
+		}
+	}
+
+	// Least trustworthy: the commit dates, which the upstream repository sets and
+	// can backdate.
+	commit, _, err := g.client.Repositories.GetCommit(ctx, owner, repo, ref, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get commit %s: %w", ref, err)
+	}
+	return commitTimestamp(commit), nil
+}
+
+// commitTimestamp returns the commit's committer date, falling back to its
+// author date, or nil when neither is set.
+func commitTimestamp(commit *github.RepositoryCommit) *Timestamp {
+	c := commit.GetCommit()
+	if c == nil {
+		return nil
+	}
+	if committer := c.GetCommitter(); committer != nil {
+		if date := committer.GetDate(); !date.Time.IsZero() {
+			return newTimestamp(date.Time, "commit")
+		}
+	}
+	if author := c.GetAuthor(); author != nil {
+		if date := author.GetDate(); !date.Time.IsZero() {
+			return newTimestamp(date.Time, "commit")
+		}
+	}
+	return nil
+}
+
 func (g *Actions) LatestVersion(ctx context.Context, value string) (string, error) {
 	githubRef, err := ParseActionRef(value)
 	if err != nil {

--- a/resolver/actions_test.go
+++ b/resolver/actions_test.go
@@ -6,6 +6,9 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/google/go-github/v89/github"
 )
 
 func TestActions_Resolve(t *testing.T) {
@@ -196,6 +199,73 @@ func TestParseActionRef(t *testing.T) {
 
 			if got, want := ref, tc.exp; !reflect.DeepEqual(got, want) {
 				t.Errorf("expected %#v to be %#v", got, want)
+			}
+		})
+	}
+}
+
+func Test_commitTimestamp(t *testing.T) {
+	t.Parallel()
+
+	committer := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	author := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name   string
+		commit *github.RepositoryCommit
+		want   time.Time
+		wantOK bool
+	}{
+		{
+			name: "prefers_committer",
+			commit: &github.RepositoryCommit{
+				Commit: &github.Commit{
+					Committer: &github.CommitAuthor{Date: &github.Timestamp{Time: committer}},
+					Author:    &github.CommitAuthor{Date: &github.Timestamp{Time: author}},
+				},
+			},
+			want:   committer,
+			wantOK: true,
+		},
+		{
+			name: "falls_back_to_author",
+			commit: &github.RepositoryCommit{
+				Commit: &github.Commit{
+					Author: &github.CommitAuthor{Date: &github.Timestamp{Time: author}},
+				},
+			},
+			want:   author,
+			wantOK: true,
+		},
+		{
+			name:   "no_dates",
+			commit: &github.RepositoryCommit{Commit: &github.Commit{}},
+		},
+		{
+			name:   "no_commit",
+			commit: &github.RepositoryCommit{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := commitTimestamp(tc.commit)
+			if !tc.wantOK {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %v, got nil", tc.want)
+			}
+			if !got.Time.Equal(tc.want) {
+				t.Errorf("expected %v, got %v", tc.want, got.Time)
+			}
+			if got.Source != "commit" {
+				t.Errorf("expected source %q, got %q", "commit", got.Source)
 			}
 		})
 	}

--- a/resolver/container.go
+++ b/resolver/container.go
@@ -50,3 +50,37 @@ func (g *Container) Resolve(ctx context.Context, value string) (string, error) {
 
 	return fmt.Sprintf("%s@%s", ref.Context().Name(), resp.Digest.String()), nil
 }
+
+// ResolvedTimestamp reports the image's config "created" time. That value is set
+// by the image builder and is not server-authoritative. Reproducible builds
+// zero it out (or set it to the Unix epoch), which is reported as nil so the
+// caller degrades gracefully.
+func (g *Container) ResolvedTimestamp(ctx context.Context, value string) (*Timestamp, error) {
+	ref, err := name.ParseReference(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Container ref: %w", err)
+	}
+
+	img, err := remote.Image(ref,
+		remote.WithContext(ctx),
+		remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch container image: %w", err)
+	}
+
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read container image config: %w", err)
+	}
+
+	return imageCreatedTimestamp(cfg.Created.Time), nil
+}
+
+// imageCreatedTimestamp wraps an image "created" time, treating the zero value
+// and the Unix epoch (both used by reproducible builds) as unknown.
+func imageCreatedTimestamp(created time.Time) *Timestamp {
+	if created.IsZero() || created.Unix() <= 0 {
+		return nil
+	}
+	return newTimestamp(created, "image")
+}

--- a/resolver/container_test.go
+++ b/resolver/container_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"regexp"
 	"testing"
+	"time"
 )
 
 func TestContainer_Resolve(t *testing.T) {
@@ -48,6 +49,55 @@ func TestContainer_Resolve(t *testing.T) {
 
 			if !match {
 				t.Errorf("expected %q to match %q", result, tc.exp)
+			}
+		})
+	}
+}
+
+func Test_imageCreatedTimestamp(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name    string
+		created time.Time
+		wantOK  bool
+	}{
+		{
+			name:    "valid",
+			created: created,
+			wantOK:  true,
+		},
+		{
+			name:    "zero",
+			created: time.Time{},
+		},
+		{
+			name:    "epoch",
+			created: time.Unix(0, 0).UTC(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := imageCreatedTimestamp(tc.created)
+			if !tc.wantOK {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %v, got nil", tc.created)
+			}
+			if !got.Time.Equal(tc.created) {
+				t.Errorf("expected %v, got %v", tc.created, got.Time)
+			}
+			if got.Source != "image" {
+				t.Errorf("expected source %q, got %q", "image", got.Source)
 			}
 		})
 	}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 )
 
 const (
@@ -24,14 +25,39 @@ type Resolver interface {
 	LatestVersion(context.Context, string) (string, error)
 }
 
+// Option configures the default resolver.
+type Option func(*resolverOptions)
+
+type resolverOptions struct {
+	bakeDelay time.Duration
+}
+
+// WithBakeDelay sets the minimum age an artifact must have before Resolve will
+// pin it. Zero or negative disables the check.
+func WithBakeDelay(d time.Duration) Option {
+	return func(o *resolverOptions) {
+		o.bakeDelay = d
+	}
+}
+
 // DefaultResolver is the default resolver.
 type DefaultResolver struct {
 	actions   *Actions
 	container *Container
+
+	// bakeDelay is the minimum age an artifact must have before Resolve will
+	// pin it. Zero or negative disables the check.
+	bakeDelay time.Duration
 }
 
-// NewDefaultResolver returns the default resolver.
-func NewDefaultResolver(ctx context.Context) (Resolver, error) {
+// NewDefaultResolver returns the default resolver. Options such as WithBakeDelay
+// customize its behavior.
+func NewDefaultResolver(ctx context.Context, opts ...Option) (Resolver, error) {
+	var o resolverOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	actions, err := NewActions(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup actions resolver: %w", err)
@@ -45,6 +71,7 @@ func NewDefaultResolver(ctx context.Context) (Resolver, error) {
 	return &DefaultResolver{
 		actions:   actions,
 		container: container,
+		bakeDelay: o.bakeDelay,
 	}, nil
 }
 
@@ -52,12 +79,59 @@ func NewDefaultResolver(ctx context.Context) (Resolver, error) {
 func (r *DefaultResolver) Resolve(ctx context.Context, ref string) (string, error) {
 	switch {
 	case strings.HasPrefix(ref, ActionsProtocol):
-		return r.actions.Resolve(ctx, strings.TrimPrefix(ref, ActionsProtocol))
+		value := strings.TrimPrefix(ref, ActionsProtocol)
+		resolved, err := r.actions.Resolve(ctx, value)
+		if err != nil {
+			return "", err
+		}
+		if err := r.checkBakeDelay(ctx, r.actions, value, resolved); err != nil {
+			return "", err
+		}
+		return resolved, nil
 	case strings.HasPrefix(ref, ContainerProtocol):
-		return r.container.Resolve(ctx, strings.TrimPrefix(ref, ContainerProtocol))
+		value := strings.TrimPrefix(ref, ContainerProtocol)
+		resolved, err := r.container.Resolve(ctx, value)
+		if err != nil {
+			return "", err
+		}
+		if err := r.checkBakeDelay(ctx, r.container, value, resolved); err != nil {
+			return "", err
+		}
+		return resolved, nil
 	default:
 		return "", fmt.Errorf("missing resolver protocol")
 	}
+}
+
+// checkBakeDelay enforces the bake delay against a resolved artifact. It is a
+// no-op when the delay is disabled or the resolver cannot report an age
+// (graceful degradation).
+func (r *DefaultResolver) checkBakeDelay(ctx context.Context, res any, ref, resolved string) error {
+	if r.bakeDelay <= 0 {
+		return nil
+	}
+
+	tr, ok := res.(TimestampResolver)
+	if !ok {
+		return nil
+	}
+
+	ts, err := tr.ResolvedTimestamp(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("failed to determine age of %s: %w", ref, err)
+	}
+	if ts == nil {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	if age := now.Sub(ts.Time); age < r.bakeDelay {
+		return fmt.Errorf(
+			"%s resolves to %s; %s dated %s (%s old) is younger than bake delay %s; wait or set -bake-delay 0",
+			ref, resolved, ts.Source, ts.Time.Format(time.RFC3339), age.Round(time.Second), r.bakeDelay,
+		)
+	}
+	return nil
 }
 
 // LatestVersion upgrades the ref.

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -1,0 +1,83 @@
+package resolver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeTimestampResolver struct {
+	ts  *Timestamp
+	err error
+}
+
+func (f fakeTimestampResolver) ResolvedTimestamp(_ context.Context, _ string) (*Timestamp, error) {
+	return f.ts, f.err
+}
+
+func Test_checkBakeDelay(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	young := &Timestamp{Time: now.Add(-1 * time.Hour), Source: "commit"}
+	old := &Timestamp{Time: now.Add(-48 * time.Hour), Source: "release"}
+
+	cases := []struct {
+		name      string
+		bakeDelay time.Duration
+		res       any
+		wantErr   bool
+	}{
+		{
+			name:      "disabled_ignores_young_artifact",
+			bakeDelay: 0,
+			res:       fakeTimestampResolver{ts: young},
+		},
+		{
+			name:      "negative_delay_ignores_young_artifact",
+			bakeDelay: -1 * time.Hour,
+			res:       fakeTimestampResolver{ts: young},
+		},
+		{
+			name:      "young_artifact_fails",
+			bakeDelay: 24 * time.Hour,
+			res:       fakeTimestampResolver{ts: young},
+			wantErr:   true,
+		},
+		{
+			name:      "old_artifact_passes",
+			bakeDelay: 24 * time.Hour,
+			res:       fakeTimestampResolver{ts: old},
+		},
+		{
+			name:      "unknown_age_degrades",
+			bakeDelay: 24 * time.Hour,
+			res:       fakeTimestampResolver{ts: nil},
+		},
+		{
+			name:      "resolver_without_capability_degrades",
+			bakeDelay: 24 * time.Hour,
+			res:       struct{}{},
+		},
+		{
+			name:      "resolver_error_propagates",
+			bakeDelay: 24 * time.Hour,
+			res:       fakeTimestampResolver{err: errors.New("boom")},
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &DefaultResolver{bakeDelay: tc.bakeDelay}
+			err := r.checkBakeDelay(ctx, tc.res, "actions/checkout@v4", "actions/checkout@abc123")
+			if got := err != nil; got != tc.wantErr {
+				t.Errorf("expected error=%v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/resolver/timestamp.go
+++ b/resolver/timestamp.go
@@ -1,0 +1,28 @@
+package resolver
+
+import (
+	"context"
+	"time"
+)
+
+// Timestamp is the most trustworthy known publish or creation time for a
+// resolved artifact, along with the source it was derived from (for example
+// "release", "tag", "commit", or "image").
+type Timestamp struct {
+	Time   time.Time
+	Source string
+}
+
+// newTimestamp builds a Timestamp with the time normalized to UTC so
+// comparisons and formatting are timezone-independent.
+func newTimestamp(t time.Time, source string) *Timestamp {
+	return &Timestamp{Time: t.UTC(), Source: source}
+}
+
+// TimestampResolver is an optional capability that a Resolver may implement to
+// report the age of a resolved artifact. It powers the bake delay. Resolvers
+// that cannot determine a time return a nil Timestamp with a nil error, and the
+// caller treats the artifact as passing the bake delay (graceful degradation).
+type TimestampResolver interface {
+	ResolvedTimestamp(ctx context.Context, ref string) (*Timestamp, error)
+}


### PR DESCRIPTION
Adds an opt-in bake delay so `pin`, `update`, and `upgrade` refuse to resolve any artifact younger than a configured duration. This narrows the window where ratchet would pin a version that was compromised and published minutes ago. pnpm calls this [`minimumReleaseAge`](https://pnpm.io/settings#minimumreleaseage); Dependabot calls it [`cooldown`](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference). It is off by default (`0`), so nothing changes for existing users.

Fixes https://github.com/sethvargo/ratchet/issues/132. Supersedes https://github.com/sethvargo/ratchet/pull/133, which solved the same issue with a different approach.

## How it works

Set `-bake-delay 24h` or `RATCHET_BAKE_DELAY=24h` (a Go duration). The check runs at pin time, so `pin`, `update`, and `upgrade` (which re-pins) are all covered. If the artifact ratchet would pin is too young, it fails with a clear error instead of silently picking an older version; wait, or pass `-bake-delay 0`.

The check is a generic resolver capability (`TimestampResolver`) enforced in one place, `DefaultResolver.Resolve`, so there is a single gate and `LatestVersion` is unchanged. A resolver that cannot determine an artifact's age lets it through rather than failing.

For GitHub Actions, ratchet uses the most trustworthy timestamp it can find:

1. Release `published_at`, which GitHub sets server-side and the upstream repo cannot backdate.
2. An annotated tag's tagger date, which catches a fresh tag pointed at an old commit.
3. The commit's committer date, then its author date.

For container images, it uses the OCI config `created` time (reproducible builds that zero it out are treated as unknown).

Tag, commit, and image dates are set by whoever produced the artifact, so only release `published_at` is server-authoritative. Bake delay reduces risk for the common case; it is not a hard boundary, and it does not detect a tag repointed at an already-old commit. The README documents this.

## Testing

Unit tests cover the timestamp trust chain (commit committer/author selection and image created/zero/epoch handling) and the enforcement branches (young, old, unknown age, resolver without the capability, and resolver error). I also verified end to end that it blocks a too-young ref, passes an old one, uses the release date for exact tags and the commit date for moving major tags, and that an unset or unparseable `RATCHET_BAKE_DELAY` leaves the delay off. `go build`, `go vet`, `gofmt`, and `go test ./...` all pass.

